### PR TITLE
match quest unlocks at KV put

### DIFF
--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 
 const roundTo = require('round-to');
 
@@ -16,7 +16,6 @@ const { initPresetSize, getPresetSize } = require('../modules/preset-size');
 
 let bsgItems = false;
 let credits = false;
-let en = false;
 let locales = false;
 let traderData = false;
 let logger = false;
@@ -46,8 +45,8 @@ const addCategory = id => {
         parent_id: null,
         locale: {}
     };
-    if (en.templates[id]) {
-        bsgCategories[id].name = en.templates[id].Name
+    if (locales.en.templates[id]) {
+        bsgCategories[id].name = locales.en.templates[id].Name
     } else {
         bsgCategories[id].name = bsgItems[id]._name;
     }
@@ -184,63 +183,93 @@ const addPropertiesToItem = (item) => {
 module.exports = async () => {
     logger = new JobLogger('update-item-cache');
     try {
-        bsgItems = await tarkovChanges.items();
-        credits = await tarkovChanges.credits();
-        en = await tarkovChanges.locale_en();
-        locales = await tarkovChanges.locales();
-        traderData = await tarkovChanges.traders();
-        const presets = JSON.parse(fs.readFileSync('./cache/presets.json'));
-        const globals = await tarkovChanges.globals();
-        const itemMap = await remoteData.get(true);
-        const itemData = {};
-        const itemTypesSet = new Set();
-        bsgCategories = {};
-        initPresetSize(bsgItems, credits);
-
         logger.time('price-yesterday-query');
-        const avgPriceYesterday = await query(`SELECT
-            avg(price) AS priceYesterday,
-            item_id
-        FROM
-            price_data
-        WHERE
-            timestamp > DATE_SUB(NOW(), INTERVAL 2 DAY)
-        AND
-            timestamp < DATE_SUB(NOW(), INTERVAL 1 DAY)
-        GROUP BY
-            item_id`);
-        logger.timeEnd('price-yesterday-query');
-
-        logger.time('last-low-price-query');
-        const lastKnownPriceData = await query(`SELECT
-            price,
-            a.timestamp,
-            a.item_id
-        FROM
-            price_data a
-        INNER JOIN (
+        const avgPriceYesterdayPromise = query(`
             SELECT
-                max(timestamp) as timestamp,
+                avg(price) AS priceYesterday,
                 item_id
             FROM
                 price_data
             WHERE
-                timestamp > '2022-06-29 01:00:00'
+                timestamp > DATE_SUB(NOW(), INTERVAL 2 DAY)
+            AND
+                timestamp < DATE_SUB(NOW(), INTERVAL 1 DAY)
             GROUP BY
                 item_id
-        ) b
-        ON
-            a.timestamp = b.timestamp
-        GROUP BY
-            item_id, timestamp, price;`);
-        logger.timeEnd('last-low-price-query');
+        `).then(results => {
+            logger.timeEnd('price-yesterday-query');
+            return results;
+        });
+
+        logger.time('last-low-price-query');
+        const lastKnownPriceDataPromise = query(`
+            SELECT
+                price,
+                a.timestamp,
+                a.item_id
+            FROM
+                price_data a
+            INNER JOIN (
+                SELECT
+                    max(timestamp) as timestamp,
+                    item_id
+                FROM
+                    price_data
+                WHERE
+                    timestamp > '2022-06-29 01:00:00'
+                GROUP BY
+                    item_id
+            ) b
+            ON
+                a.timestamp = b.timestamp
+            GROUP BY
+                item_id, timestamp, price;
+        `).then(results => {
+            logger.timeEnd('last-low-price-query');
+            return results;
+        });
 
         logger.time('contained-items-query');
-        const containedItems = await query(`SELECT
-            *
-        FROM
-            item_children;`);
-        logger.timeEnd('contained-items-query');
+        const containedItemsPromise = query(`
+            SELECT
+                *
+            FROM
+                item_children;
+        `).then (results => {
+            logger.timeEnd('contained-items-query');
+            return results;
+        });
+
+        let presets, globals, avgPriceYesterday, lastKnownPriceData, containedItems, itemMap;
+        [
+            bsgItems, 
+            credits, 
+            locales, 
+            traderData, 
+            globals, 
+            presets,
+            avgPriceYesterday, 
+            lastKnownPriceData, 
+            containedItems, 
+            itemMap
+        ] = await Promise.all([
+            tarkovChanges.items(), 
+            tarkovChanges.credits(),
+            tarkovChanges.locales(),
+            tarkovChanges.traders(),
+            tarkovChanges.globals(),
+            fs.readFile('./cache/presets.json').then(text => {
+                return JSON.parse(text);
+            }),
+            avgPriceYesterdayPromise,
+            lastKnownPriceDataPromise,
+            containedItemsPromise,
+            remoteData.get(true)
+        ]);
+        const itemData = {};
+        const itemTypesSet = new Set();
+        bsgCategories = {};
+        initPresetSize(bsgItems, credits);
 
         let containedItemsMap = {};
 
@@ -557,5 +586,5 @@ module.exports = async () => {
     }
     await jobComplete();
     logger.end();
-    bsgItems = credits = en = locales = traderData = bsgCategories = logger = false;
+    bsgItems = credits = locales = traderData = bsgCategories = logger = false;
 };

--- a/src/tarkov-data-manager/jobs/update-trader-prices.js
+++ b/src/tarkov-data-manager/jobs/update-trader-prices.js
@@ -6,6 +6,7 @@ const { query, jobComplete } = require('../modules/db-connection');
 const JobLogger = require('../modules/job-logger');
 const {alert} = require('../modules/webhook');
 const tarkovChanges = require('../modules/tarkov-changes');
+const api = require('../modules/api-query');
 
 const traderMap = {
     'prapor': '54cb50c76803fa8b248b4571',
@@ -26,7 +27,7 @@ const traderMap = {
     'Jaeger': '5c0647fdd443bc2504c2d371',
 };
 
-let logger = false;
+let logger, tasks;
 
 const outputPrices = async (prices) => {
     try {
@@ -54,19 +55,42 @@ const outputPrices = async (prices) => {
     logger = false;
 };
 
+const getQuestUnlock = (traderItem) => {
+    if (!isNaN(parseInt(traderItem.quest_unlock_id)) || traderItem.quest_unlock_bsg_id) {
+        const traderId = traderMap[traderItem.trader_name];
+        const itemId = traderItem.item_id;
+        for (const quest of tasks) {
+            const match = unlockMatches(itemId, quest.startRewards, traderId) || unlockMatches(itemId, quest.finishRewards, traderId);
+            if (match) {
+                return {
+                    id: quest.id,
+                    tarkovDataId: quest.tarkovDataId,
+                    level: match.level
+                };
+            }
+        }
+        logger.warn(`Could not find quest unlock for trader offer ${traderItem.id}`);
+    }
+    return false;
+};
+
+const unlockMatches = (itemId, rewards, traderId) => {
+    if (!rewards || !rewards.offerUnlock) return false;
+    for (const unlock of rewards.offerUnlock) {
+        if (unlock.trader.id !== traderId) continue;
+        const item = unlock.item;
+        if (item.id === itemId) return unlock;
+        if (item.types.includes('preset') && item.properties.baseItem.id === itemId) {
+            return unlock;
+        }
+    }
+    return false;
+};
+
 module.exports = async () => {
     logger = new JobLogger('update-trader-prices');
     try {
-        let tdQuests = {};
-        try {
-            const response = await got('https://raw.githubusercontent.com/TarkovTracker/tarkovdata/master/quests.json', {
-                responseType: 'json',
-            });
-            tdQuests = response.body;
-        } catch (error) {
-            logger.error('Error downloading TarkovData quests');
-            logger.error(error);
-        }
+        const taskPromise = api.tasks();
         const outputData = {};
         const junkboxLastScan = await query(`
             SELECT
@@ -166,19 +190,25 @@ module.exports = async () => {
             currenciesThen[currencyISO[curr.item_id]] = curr.price;
         }
 
-        const traderItems = await query(`SELECT
-            *
-        FROM
-            trader_items;`);
+        const traderItems = await query(`
+            SELECT
+                *
+            FROM
+                trader_items;
+        `);
 
-        const traderPriceData = await query(`SELECT
-            *
-        FROM
-            trader_price_data
-        WHERE
-            timestamp > ?;`, [scanOffsetTimestampMoment]);
+        const traderPriceData = await query(`
+            SELECT
+                *
+            FROM
+                trader_price_data
+            WHERE
+                timestamp > ?;
+        `, [scanOffsetTimestampMoment]);
 
         const latestTraderPrices = {};
+
+        tasks = await taskPromise;
 
         for(const traderPrice of traderPriceData){
             if(!latestTraderPrices[traderPrice.trade_id]){
@@ -217,45 +247,38 @@ module.exports = async () => {
             if (currencyISO[traderItem.item_id]) {
                 itemPrice = currenciesNow[currencyISO[traderItem.item_id]];
             }
-            let questBsgId = null;
-            if (!isNaN(parseInt(traderItem.quest_unlock_id))) {
-                for (const quest of tdQuests) {
-                    if (quest.id == traderItem.quest_unlock_id) {
-                        questBsgId = quest.gameId;
-                        break;
-                    }
-                }
-                if (!questBsgId) {
-                    logger.warn(`Could not find bsg id for quest ${traderItem.quest_unlock_id}`);
-                }
+            let minLevel = traderItem.min_level;
+            const questUnlock = getQuestUnlock(traderItem);
+            if (questUnlock) {
+                minLevel = questUnlock.level;
             }
             const offer = {
                 id: traderItem.item_id,
                 vendor: {
                     trader: traderMap[traderItem.trader_name],
                     trader_id: traderMap[traderItem.trader_name],
-                    traderLevel: traderItem.min_level,
-                    minTraderLevel: traderItem.min_level,
-                    taskUnlock: questBsgId
+                    traderLevel: minLevel,
+                    minTraderLevel: minLevel,
+                    taskUnlock: questUnlock ? questUnlock.id : null
                 },
                 source: traderItem.trader_name,
                 price: itemPrice,
                 priceRUB: Math.round(itemPrice * currenciesNow[traderItem.currency]),
                 updated: latestTraderPrices[traderItem.id].timestamp,
-                quest_unlock: !isNaN(parseInt(traderItem.quest_unlock_id)),
+                quest_unlock: questUnlock !== false,
                 quest_unlock_id: traderItem.quest_unlock_id,
                 currency: traderItem.currency,
                 currencyItem: currencyId[traderItem.currency],
                 requirements: [{
                     type: 'loyaltyLevel',
-                    value: traderItem.min_level,
+                    value: minLevel,
                 }]
             };
-            if (offer.quest_unlock) {
+            if (questUnlock) {
                 offer.requirements.push({
                     type: 'questCompleted',
-                    value: Number(offer.quest_unlock_id) || 1,
-                    stringValue: questBsgId
+                    value: Number(questUnlock.tarkovDataId) || 1,
+                    stringValue: questUnlock.id
                 });
             }
             outputData[traderItem.item_id].push(offer);

--- a/src/tarkov-data-manager/modules/api-query.js
+++ b/src/tarkov-data-manager/modules/api-query.js
@@ -1,0 +1,88 @@
+const got = require('got');
+
+const apiUrl = 'https://api.tarkov.dev/graphql';
+//const apiUrl = 'https://dev-api.tarkov.dev/graphql';
+//const apiUrl = 'http://localhost:8787/graphql';
+
+const query = async (graphql) => {
+    return got(apiUrl, {
+        method: 'post',
+        json: {
+            query: `{
+                ${graphql}
+            }`
+        },
+        responseType: 'json',
+        resolveBodyOnly: true
+    });
+};
+
+const tasks = async () => {
+    const response = await query(`
+        tasks {
+          id
+          tarkovDataId
+          name
+          startRewards {
+            offerUnlock {
+              trader {
+                id
+                name
+              }
+              level
+              item {
+                id
+                name
+                types
+                properties {
+                  ...on ItemPropertiesPreset {
+                    baseItem {
+                      id
+                    }
+                  }
+                }
+                containsItems {
+                  item {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }
+          finishRewards {
+            offerUnlock {
+              trader {
+                id
+                name
+              }
+              level
+              item {
+                id
+                name
+                types
+                properties {
+                  ...on ItemPropertiesPreset {
+                    baseItem {
+                      id
+                    }
+                  }
+                }
+                containsItems {
+                  item {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    `);
+    return response.data.tasks;
+};
+
+module.exports = {
+    query: query,
+    tasks: tasks
+};


### PR DESCRIPTION
Currently, quest unlocks are matched at the time a trader price is scanned. With this update, the data manager attempts to match the quest when processing trader prices to be uploaded to the KV. This allows for quest unlocks to be updated without having to re-scan items.

Also includes some optimizations for the update-item-cache job.