### PR TITLE
don't check scans when game updating

### DIFF
--- a/src/tarkov-data-manager/jobs/check-scans.js
+++ b/src/tarkov-data-manager/jobs/check-scans.js
@@ -9,15 +9,19 @@ const scannerApi = require('../modules/scanner-api');
 module.exports = async () => {
     const logger = new JobLogger('check-scans');
     try {
-        eftMessages = await got('https://status.escapefromtarkov.com/api/message/list', {
-                responseType: 'json',
-                resolveBodyOnly: true
-            });
-        if (eftMessages[0].type === 1) {
-            logger.log('Game is updating, skipping scan check')
-            await jobComplete();
-            logger.end();
-            return;
+        const services = await got('https://status.escapefromtarkov.com/api/services', {
+            responseType: 'json',
+            resolveBodyOnly: true
+        });
+
+        for (const service of services) {
+            if (!service.name === 'Trading') continue;
+            if (service.status === 1) {
+                logger.log('Game is updating, skipping scan check')
+                await jobComplete();
+                logger.end();
+                return;
+            }
         }
     } catch (error) {
         logger.error(`Error checking EFT status messages: ${error.message}`);

--- a/src/tarkov-data-manager/jobs/check-scans.js
+++ b/src/tarkov-data-manager/jobs/check-scans.js
@@ -1,3 +1,5 @@
+const got = require('got');
+
 const { query, jobComplete } = require('../modules/db-connection');
 const webhook = require('../modules/webhook');
 const JobLogger = require('../modules/job-logger');
@@ -6,6 +8,20 @@ const scannerApi = require('../modules/scanner-api');
 
 module.exports = async () => {
     const logger = new JobLogger('check-scans');
+    try {
+        eftMessages = await got('https://status.escapefromtarkov.com/api/message/list', {
+                responseType: 'json',
+                resolveBodyOnly: true
+            });
+        if (eftMessages[0].type === 1) {
+            logger.log('Game is updating, skipping scan check')
+            await jobComplete();
+            logger.end();
+            return;
+        }
+    } catch (error) {
+        logger.error(`Error checking EFT status messages: ${error.message}`);
+    }
     try {
         const scanners = await query(`
             select scanner.id, name, last_scan, username, scanner.flags, scanner_user.flags as user_flags, disabled 


### PR DESCRIPTION
No need to send alerts on missing scans when the game is updating and the scanners can't scan anything.