### PR TITLE
Reduce Historical Item Prirces job to once per hour; cron info

### DIFF
--- a/src/tarkov-data-manager/index.js
+++ b/src/tarkov-data-manager/index.js
@@ -1177,6 +1177,7 @@ app.get('/crons', async (req, res) => {
     res.send(`${getHeader(req, {include: 'datatables'})}
         <script src="/ansi_up.js"></script>
         <script src="/crons.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/cronstrue/2.11.0/cronstrue.min.js"></script>
         <div class="row">
             <div class="col s10 offset-s1">
                 <div>
@@ -1228,6 +1229,8 @@ app.get('/crons', async (req, res) => {
                                 <input value="" id="schedule" type="text" class="validate schedule" name="schedule">
                                 <label for="schedule">Schedule</label>
                             </div>
+                        </div>
+                        <div class="row cronstrue">
                         </div>
                         <input value="" id="jobName" type="hidden" name="jobName" class="jobName">
                     </form>

--- a/src/tarkov-data-manager/jobs/index.js
+++ b/src/tarkov-data-manager/jobs/index.js
@@ -33,7 +33,7 @@ const defaultJobs = {
     'update-crafts': '1-59/5 * * * *',
     'update-existing-bases': '4-59/5 * * * *',
     'game-data': '*/10 * * * *',
-    'update-historical-prices': '5-59/15 * * * *',
+    'update-historical-prices': '30 */2 * * *',
     'update-trader-prices': '25 9,21 * * *',
     'clear-checkouts': '5,35 * * * *',
     'verify-wiki': '5 9 * * *',

--- a/src/tarkov-data-manager/jobs/index.js
+++ b/src/tarkov-data-manager/jobs/index.js
@@ -33,7 +33,7 @@ const defaultJobs = {
     'update-crafts': '1-59/5 * * * *',
     'update-existing-bases': '4-59/5 * * * *',
     'game-data': '*/10 * * * *',
-    'update-historical-prices': '30 */2 * * *',
+    'update-historical-prices': '30 * * * *',
     'update-trader-prices': '25 9,21 * * *',
     'clear-checkouts': '5,35 * * * *',
     'verify-wiki': '5 9 * * *',

--- a/src/tarkov-data-manager/public/crons.js
+++ b/src/tarkov-data-manager/public/crons.js
@@ -21,7 +21,13 @@ $(document).ready( function () {
             }
         },
         {
-            data: 'schedule'
+            data: 'schedule',
+            render: (data, type, cron) => {
+                if (type !== 'display') {
+                    return data;
+                }
+                return `<span class="tooltipped" data-tooltip="${window.cronstrue.toString(data)}">${data}</span>`
+            }
         },
         {
             data: 'lastRun',
@@ -68,6 +74,7 @@ $(document).ready( function () {
                 $('#modal-edit-cron .schedule').val(target.data('schedule'));
                 M.Modal.getInstance(document.getElementById('modal-edit-cron')).open();
                 M.updateTextFields();
+                $('#modal-edit-cron .schedule').keyup();
                 $('#modal-edit-cron .schedule').focus();
             });
 
@@ -113,6 +120,16 @@ $(document).ready( function () {
                     $('#modal-view-cron-log .log-messages').html(logMessages.join('<br>'));
                 });
             });
+        }
+    });
+
+    $('#schedule').keyup(event => {
+        const input = $(event.target);
+        try {
+            $('#modal-edit-cron .cronstrue').text(window.cronstrue.toString(input.val()));
+        } catch (error) {
+            console.log(error);
+            $('#modal-edit-cron .cronstrue').text('');
         }
     });
 


### PR DESCRIPTION
Reduces the update-historical-prices job to run once per hour. Also provides human-readable info about the cron schedules via tooltip.