### PR TITLE
Use SPT lang files temporarily

### DIFF
--- a/src/tarkov-data-manager/modules/tarkov-changes.js
+++ b/src/tarkov-data-manager/modules/tarkov-changes.js
@@ -44,7 +44,8 @@ const availableFiles = {
     },
     locale_en: {
         requestName: 'locale_en_td.json',
-        fileName: 'locale_en.json'
+        fileName: 'locale_en.json',
+        skip: true,
     },
 };
 

--- a/src/tarkov-data-manager/modules/tarkov-data.js
+++ b/src/tarkov-data-manager/modules/tarkov-data.js
@@ -22,8 +22,8 @@ module.exports = {
         return tarkovChanges.items(download);
     },
     locale: (lang = 'en', download = false) => {
-        if (lang == 'en') return tarkovChanges.locale_en(download);
-        if (lang == 'ru') return tarkovBot.locale('ru', download);
+        //if (lang == 'en') return tarkovChanges.locale_en(download);
+        //if (lang == 'ru') return tarkovBot.locale('ru', download);
         return spt.locale(lang, download);
     },
     locales: async (download = false) => {

--- a/src/tarkov-data-manager/modules/tarkov-spt.js
+++ b/src/tarkov-data-manager/modules/tarkov-spt.js
@@ -7,7 +7,7 @@ const got = require('got');
 const sptPath = 'https://dev.sp-tarkov.com/SPT-AKI/Server/raw/branch/development/project/assets/database/';
 
 const sptLangs = {
-    //'en': 'en',
+    'en': 'en',
     'es': 'es',
     'de': 'ge',
     'fr': 'fr',
@@ -17,7 +17,7 @@ const sptLangs = {
     'ja': 'jp',
     'pl': 'pl',
     'pt': 'po',
-    //'ru': 'ru',
+    'ru': 'ru',
     'sk': 'sk',
     'tr': 'tu',
     'zh': 'ch',

--- a/src/tarkov-data-manager/modules/tarkov-spt.js
+++ b/src/tarkov-data-manager/modules/tarkov-spt.js
@@ -15,6 +15,7 @@ const sptLangs = {
     'hu': 'hu',
     'it': 'it',
     'ja': 'jp',
+    'ko': 'kr',
     'pl': 'pl',
     'pt': 'po',
     'ru': 'ru',


### PR DESCRIPTION
This is a temporary PR that switches the lang files to all come from SPT since BSG has changed the format of the language files.

This PR doesn't need to be merged. Once we have access to all language files in the new format, we can deploy #170 and close this one.