### PR TITLE
Better images

### DIFF
--- a/src/tarkov-data-manager/package-lock.json
+++ b/src/tarkov-data-manager/package-lock.json
@@ -35,7 +35,7 @@
         "parse-duration": "^1.0.2",
         "round-to": "^5.0.0",
         "sharp": "0.31.0",
-        "tarkov-dev-image-generator": "^2.1.14",
+        "tarkov-dev-image-generator": "^2.1.15",
         "unidecode": "^0.1.8"
       },
       "engines": {
@@ -4230,9 +4230,9 @@
       }
     },
     "node_modules/tarkov-dev-image-generator": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/tarkov-dev-image-generator/-/tarkov-dev-image-generator-2.1.14.tgz",
-      "integrity": "sha512-j9ildvJ9Rty+aeu0ZIbK2XJxsqZ4AUoWnPmI5ZzoDHsb4j+Jb1D6yRl/MoW/vMdRfQt651Z23K8mhl3cai6q3A==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/tarkov-dev-image-generator/-/tarkov-dev-image-generator-2.1.15.tgz",
+      "integrity": "sha512-5J/x/0oZSJGhlhkf2NwnVeylROCIXL6AS0Oo4lJBrONl7FeYO4nT3pr8Jo3w6QaOJ5Y1ZAiu0H1RKITJkln8sA==",
       "dependencies": {
         "@jimp/plugin-shadow": "0.16.1",
         "dotenv": "^16.0.0",
@@ -7775,9 +7775,9 @@
       }
     },
     "tarkov-dev-image-generator": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/tarkov-dev-image-generator/-/tarkov-dev-image-generator-2.1.14.tgz",
-      "integrity": "sha512-j9ildvJ9Rty+aeu0ZIbK2XJxsqZ4AUoWnPmI5ZzoDHsb4j+Jb1D6yRl/MoW/vMdRfQt651Z23K8mhl3cai6q3A==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/tarkov-dev-image-generator/-/tarkov-dev-image-generator-2.1.15.tgz",
+      "integrity": "sha512-5J/x/0oZSJGhlhkf2NwnVeylROCIXL6AS0Oo4lJBrONl7FeYO4nT3pr8Jo3w6QaOJ5Y1ZAiu0H1RKITJkln8sA==",
       "requires": {
         "@jimp/plugin-shadow": "0.16.1",
         "dotenv": "^16.0.0",

--- a/src/tarkov-data-manager/package.json
+++ b/src/tarkov-data-manager/package.json
@@ -43,7 +43,7 @@
     "parse-duration": "^1.0.2",
     "round-to": "^5.0.0",
     "sharp": "0.31.0",
-    "tarkov-dev-image-generator": "^2.1.14",
+    "tarkov-dev-image-generator": "^2.1.15",
     "unidecode": "^0.1.8"
   }
 }


### PR DESCRIPTION
Bump img gen library. Switches all images to webp and improves accuracy of icons and grid images.