### PR TITLE
Preset prices only include items each trader buys

### DIFF
--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -569,7 +569,7 @@ class UpdateItemCacheJob extends DataJob {
         const currencyId = dataMaps.currencyIsoId;
 
         for (const trader of this.traderData) {
-            if (trader.items_buy_prohibited.id_list.includes(item.id)) {
+            if (trader.items_buy_prohibited.id_list.includes(item.id) || dataMaps.sellToTrader[trader.name]?.prohibitedAdded?.ids.includes(item.id)) {
                 continue;
             }
             if (trader.items_buy_prohibited.category.some(bannedCatId => item.categories.includes(bannedCatId))) {

--- a/src/tarkov-data-manager/jobs/update-presets.js
+++ b/src/tarkov-data-manager/jobs/update-presets.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const normalizeName = require('../modules/normalize-name');
-const { initPresetSize, getPresetSize } = require('../modules/preset-size');
+const { initPresetData, getPresetData } = require('../modules/preset-data');
 const tarkovData = require('../modules/tarkov-data');
 const { getTranslations, setLocales } = require('../modules/get-translation');
 const remoteData = require('../modules/remote-data');
@@ -27,7 +27,7 @@ class UpdatePresetsJob extends DataJob {
 
         setLocales(locales);
 
-        initPresetSize(items, credits);
+        initPresetData(items, credits);
 
         const manualPresets = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'manual_presets.json')));
 
@@ -111,16 +111,16 @@ class UpdatePresetsJob extends DataJob {
                 presetData.default = false;
             }
             presetData.normalized_name = normalizeName(presetData.name);
-            let itemPresetSize = await getPresetSize(presetData, this.logger);
-            if (itemPresetSize) {
-                presetData.width = itemPresetSize.width;
-                presetData.height = itemPresetSize.height;
-                presetData.weight = itemPresetSize.weight;
-                presetData.baseValue = itemPresetSize.baseValue;//credits[baseItem._id];
-                presetData.ergonomics = itemPresetSize.ergonomics;
-                presetData.verticalRecoil = itemPresetSize.verticalRecoil;
-                presetData.horizontalRecoil = itemPresetSize.horizontalRecoil;
-                presetData.moa = itemPresetSize.moa;
+            let itemPresetData = await getPresetData(presetData, this.logger);
+            if (itemPresetData) {
+                presetData.width = itemPresetData.width;
+                presetData.height = itemPresetData.height;
+                presetData.weight = itemPresetData.weight;
+                presetData.baseValue = itemPresetData.baseValue;//credits[baseItem._id];
+                presetData.ergonomics = itemPresetData.ergonomics;
+                presetData.verticalRecoil = itemPresetData.verticalRecoil;
+                presetData.horizontalRecoil = itemPresetData.horizontalRecoil;
+                presetData.moa = itemPresetData.moa;
             }
             presetsData[presetId] = presetData;
             if (presetData.default && !defaults[firstItem.id]) {
@@ -138,15 +138,15 @@ class UpdatePresetsJob extends DataJob {
             presetData.bsgCategoryId = baseItem._parent;
             presetData.types = ['preset'];
 
-            let itemPresetSize = await getPresetSize(presetData, this.logger);
-            if (itemPresetSize) {
-                presetData.width = itemPresetSize.width;
-                presetData.height = itemPresetSize.height;
-                presetData.weight = itemPresetSize.weight;
-                presetData.baseValue = itemPresetSize.baseValue;
-                presetData.ergonomics = itemPresetSize.ergonomics;
-                presetData.verticalRecoil = itemPresetSize.verticalRecoil;
-                presetData.horizontalRecoil = itemPresetSize.horizontalRecoil;
+            let itemPresetData = await getPresetData(presetData, this.logger);
+            if (itemPresetData) {
+                presetData.width = itemPresetData.width;
+                presetData.height = itemPresetData.height;
+                presetData.weight = itemPresetData.weight;
+                presetData.baseValue = itemPresetData.baseValue;
+                presetData.ergonomics = itemPresetData.ergonomics;
+                presetData.verticalRecoil = itemPresetData.verticalRecoil;
+                presetData.horizontalRecoil = itemPresetData.horizontalRecoil;
             } else {
                 presetData.width = baseItem._props.Width;
                 presetData.height = baseItem._props.Height;

--- a/src/tarkov-data-manager/modules/data-map.js
+++ b/src/tarkov-data-manager/modules/data-map.js
@@ -31,5 +31,20 @@ module.exports = {
         RUB: '5449016a4bdc2d6f028b456f',
         USD: '5696686a4bdc2da3298b456a',
         EUR: '569668774bdc2da2298b4568'
+    },
+    sellToTrader: {
+        Skier: {
+            allowedAdded: {
+                ids: [],
+                categories: [],
+            },
+            prohibitedAdded: {
+                ids: [
+                    '5a33a8ebc4a282000c5a950d',
+                    '5644bd2b4bdc2d3b4c8b4572',
+                ],
+                categories: [],
+            }
+        }
     }
 };

--- a/src/tarkov-data-manager/modules/preset-data.js
+++ b/src/tarkov-data-manager/modules/preset-data.js
@@ -1,9 +1,9 @@
-const tarkovData = require('../modules/tarkov-data');
+const tarkovData = require('./tarkov-data');
 
 let itemData = false;
 let credits = false;
 
-const getPresetSize = async (item, logger = false) => {
+const getPresetData = async (item, logger = false) => {
     if(!itemData){
         itemData = await tarkovData.items();
     }
@@ -94,9 +94,9 @@ const getPresetSize = async (item, logger = false) => {
 };
 
 module.exports = {
-    initPresetSize:( bsgItemsData, creditsData) => {
+    initPresetData:( bsgItemsData, creditsData) => {
         itemData = bsgItemsData;
         credits = creditsData;
     },
-    getPresetSize: getPresetSize
+    getPresetData
 }


### PR DESCRIPTION
Previously, if a trader purchased a base weapon, the trader would also purchaser any attachments on that weapon even if the trader would normally not purchase those attachments on their own. BSG recently changed this so that if a weapon has any "bad" attachments, the trader will not buy it. This PR changes trader sell prices for presets to only include the items each trader will buy.