### PR TITLE
Unpack ammo barters

### DIFF
--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -923,8 +923,8 @@
             "minPlayerLevel": 55,
             "taskRequirements": [
                 {
-                    "task": "60e71c9ad54b755a3b53eb66",
-                    "name": "The Cleaner",
+                    "task": "5c0d4e61d09282029f53920e",
+                    "name": "The Guide",
                     "status": [
                         "complete"
                     ]

--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -921,15 +921,7 @@
         "name": "Trophies",
         "propertiesChanged" : {
             "minPlayerLevel": 55,
-            "taskRequirements": [
-                {
-                    "task": "5c0d4e61d09282029f53920e",
-                    "name": "The Guide",
-                    "status": [
-                        "complete"
-                    ]
-                }
-            ]
+            "taskRequirements": []
         }
     },
     "60e71d23c1bfa3050473b8e6": {

--- a/src/tarkov-data-manager/jobs/update-hideout.js
+++ b/src/tarkov-data-manager/jobs/update-hideout.js
@@ -136,6 +136,15 @@ class UpdateHideoutJob extends DataJob {
                         continue;
                     }
                 }
+                //ensure all modules require the previous module
+                if (stageData.level > 1 && !stageData.stationLevelRequirements.some(req => req.station === stationData.id)) {
+                    stageData.stationLevelRequirements.push({
+                        id: `${stationData.id}-${i}-${stage.requirements.length}`,
+                        station: stationData.id,
+                        name: stationData.name,
+                        level: stageData.level - 1,
+                    });
+                }
                 stationData.levels.push(stageData);
             }
             hideoutData.HideoutStation.push(stationData);

--- a/src/tarkov-data-manager/jobs/update-hideout.js
+++ b/src/tarkov-data-manager/jobs/update-hideout.js
@@ -138,6 +138,7 @@ class UpdateHideoutJob extends DataJob {
                 }
                 //ensure all modules require the previous module
                 if (stageData.level > 1 && !stageData.stationLevelRequirements.some(req => req.station === stationData.id)) {
+                    this.logger.warn(`Added level ${stageData.level-1} as requirement for level ${stageData.level}`);
                     stageData.stationLevelRequirements.push({
                         id: `${stationData.id}-${i}-${stage.requirements.length}`,
                         station: stationData.id,

--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -215,7 +215,7 @@ class UpdateItemCacheJob extends DataJob {
                         item: round,
                         count: count,
                         attributes: []
-                    })
+                    });
                 }
             } else if (this.presets[key]) {
                 const preset = this.presets[key];

--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -300,7 +300,7 @@ class UpdateItemCacheJob extends DataJob {
 
         // Add trader prices
         for (const id in itemData) {
-            if (itemData[id].types.includes('preset')) {
+            if (itemData[id].types.includes('preset') && id !== 'customdogtags12345678910') {
                 itemData[id].traderPrices = itemData[id].containsItems.reduce((traderPrices, part) => {
                     const partPrices = this.getTraderPrices(itemData[part.item]);
                     for (const partPrice of partPrices) {


### PR DESCRIPTION
Barters that provide ammo boxes are now duplicated to also provide barters for the correct amount of ammo contained in the ammo boxes. This helps evaluate the value of these barters.

Resolves the-hideout/tarkov-api/issues/178