### PR TITLE
Streamline how localizations are used

### DIFF
--- a/src/tarkov-data-manager/jobs/update-crafts.js
+++ b/src/tarkov-data-manager/jobs/update-crafts.js
@@ -10,12 +10,12 @@ class UpdateCraftsJob extends DataJob {
 
     run = async () => {
         this.logger.log('Loading json files...');
-        const [items, json, en, processedItems] = await Promise.all([
+        const [items, json, processedItems] = await Promise.all([
             tarkovData.items(),
             tarkovData.crafts(),
-            tarkovData.locale('en'),
             remoteData.get(),
         ]);
+        const en = this.locales.en;
         const areas = await this.jobManager.jobOutput('update-hideout', this);
         const tasks = await this.jobManager.jobOutput('update-quests', this);
         const presets = await this.jobManager.jobOutput('update-presets', this, true);
@@ -54,8 +54,8 @@ class UpdateCraftsJob extends DataJob {
                     endProduct = processedItems.get(preset.id);
                 }
             }
-            if (!stations[station.locale.en.name]) {
-                stations[station.locale.en.name] = 0;
+            if (!stations[en[station.name]]) {
+                stations[en[station.name]] = 0;
             }
             const craftData = {
                 id: id,
@@ -69,7 +69,7 @@ class UpdateCraftsJob extends DataJob {
                 }],
                 station: station.id,
                 station_id: station.id,
-                sourceName: station.locale.en.name,
+                sourceName: en[station.name],
                 duration: craft.productionTime,
                 requirements: []
             };
@@ -188,9 +188,9 @@ class UpdateCraftsJob extends DataJob {
                 });
                 craftData.level = 1;
             }
-            craftData.source = `${station.locale.en.name} level ${craftData.level}`;
+            craftData.source = `${en[station.name]} level ${craftData.level}`;
             crafts.Craft.push(craftData);
-            stations[station.locale.en.name]++;
+            stations[en[station.name]]++;
         }
         for (const stationName in stations) {
             this.logger.log(`✔️ ${stationName}: ${stations[stationName]}`);

--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -6,7 +6,6 @@ const {dashToCamelCase, camelCaseToTitleCase} = require('../modules/string-funct
 const { setItemPropertiesOptions, getSpecialItemProperties } = require('../modules/get-item-properties');
 const { initPresetData, getPresetData } = require('../modules/preset-data');
 const normalizeName = require('../modules/normalize-name');
-const { setLocales, getTranslations } = require('../modules/get-translation');
 const DataJob = require('../modules/data-job');
 
 class UpdateItemCacheJob extends DataJob {
@@ -100,7 +99,6 @@ class UpdateItemCacheJob extends DataJob {
             itemIds: [...itemMap.keys()],
             disabledItemIds: [...itemMap.values()].filter(item => item.types.includes('disabled')).map(item => item.id)
         });
-        setLocales(this.locales);
         for (const [key, value] of itemMap.entries()) {
             if (value.types.includes('disabled') || value.types.includes('quest'))
                 continue;
@@ -109,7 +107,8 @@ class UpdateItemCacheJob extends DataJob {
 
             itemData[key] = {
                 ...value,
-                shortName: value.short_name,
+                name: `${key} Name`,
+                shortName: `${key} ShortName`,
                 normalizedName: value.normalized_name,
                 lastOfferCount: value.last_offer_count,
                 types: value.types.map(type => dashToCamelCase(type)).filter(type => type !== 'onlyFlea'),
@@ -281,15 +280,11 @@ class UpdateItemCacheJob extends DataJob {
 
             // translations
             if (this.locales.en[`${key} Name`]) { 
-                itemData[key].locale = getTranslations({
-                    name: `${key} Name`,
-                    shortName: `${key} ShortName`,
-                    description: `${key} Description`,
-                }, this.logger);
+                itemData[key].description = this.addTranslation(`${key} Description`);
             } else if (this.presets[key]) {
-                itemData[key].locale = {};
-                for (const code in this.locales) {
-                    itemData[key].locale[code] = this.presets[key].locale[code];
+                for (const langCode in this.presets[key].locale) {
+                    this.addTranslation(`${key} Name`, langCode, this.presets[key].locale[langCode].name);
+                    this.addTranslation(`${key} ShortName`, langCode, this.presets[key].locale[langCode].shortName);
                 }
             }
 
@@ -394,19 +389,19 @@ class UpdateItemCacheJob extends DataJob {
         }
 
         const fleaData = {
-            name: 'Flea Market',
+            name: 'FleaMarket',
             normalizedName: 'flea-market',
             minPlayerLevel: this.globals.config.RagFair.minUserLevel,
             enabled: this.globals.config.RagFair.enabled,
             sellOfferFeeRate: (this.globals.config.RagFair.communityItemTax / 100),
             sellRequirementFeeRate: (this.globals.config.RagFair.communityRequirementTax / 100),
             reputationLevels: [],
-            locale: getTranslations({name: lang => {
-                return lang['RAG FAIR'].replace(/(?<!^|\s)\p{Lu}/gu, substr => {
-                    return substr.toLowerCase();
-                });
-            }}, this.logger),
         };
+        for (const langCode in this.locales) {
+            this.addTranslation('FleaMarket', langCode, this.locales[langCode]['RAG FAIR'].replace(/(?<!^|\s)\p{Lu}/gu, substr => {
+                return substr.toLowerCase();
+            }));
+        }
         for (const offerCount of this.globals.config.RagFair.maxActiveOfferCount) {
             if (fleaData.reputationLevels.length > 0 && fleaData.reputationLevels[fleaData.reputationLevels.length-1].offers == offerCount.count) {
                 fleaData.reputationLevels[fleaData.reputationLevels.length-1].maxRep = offerCount.to;
@@ -424,8 +419,7 @@ class UpdateItemCacheJob extends DataJob {
             const armorType = this.globals.config.ArmorMaterials[armorTypeId];
             armorData[armorTypeId] = {
                 id: armorTypeId,
-                name: this.locales.en['Mat'+armorTypeId],
-                locale: getTranslations({name: `Mat${armorTypeId}`}, this.logger),
+                name: this.addTranslation('Mat'+armorTypeId),
             };
             for (const key in armorType) {
                 armorData[armorTypeId][key.charAt(0).toLocaleLowerCase()+key.slice(1)] = armorType[key];
@@ -449,7 +443,8 @@ class UpdateItemCacheJob extends DataJob {
             FleaMarket: fleaData,
             ArmorMaterial: armorData,
             PlayerLevel: levelData,
-            LanguageCode: Object.keys(this.locales).sort()
+            LanguageCode: Object.keys(this.locales).sort(),
+            ...this.kvData,
         };
         await this.cloudflarePut(itemsData);
 
@@ -473,24 +468,22 @@ class UpdateItemCacheJob extends DataJob {
             id: id,
             parent_id: this.bsgItems[id]._parent,
             child_ids: [],
-            locale: getTranslations({
-                name: (lang, langCode) => {
-                    if (lang[`${id} Name`]) {
-                        return lang[`${id} Name`];
-                    } else {
-                        if (langCode === 'en') {
-                            this.logger.warn(`${id} ${this.bsgItems[id]._name} category mising translation`);
-                        }
-                        if (langCode !== 'en' && this.locales.en[`${id} Name`]) {
-                            return this.locales.en[`${id} Name`];
-                        }
-                        return camelCaseToTitleCase(this.bsgItems[id]._name);
+            name: this.addTranslation(`${id} Name`, (lang, langCode) => {
+                if (lang[`${id} Name`]) {
+                    return lang[`${id} Name`];
+                } else {
+                    if (langCode === 'en') {
+                        this.logger.warn(`${id} ${this.bsgItems[id]._name} category mising translation`);
                     }
+                    if (langCode !== 'en' && this.locales.en[`${id} Name`]) {
+                        return this.locales.en[`${id} Name`];
+                    }
+                    return camelCaseToTitleCase(this.bsgItems[id]._name);
                 }
-            }, this.logger)
+            }),
         };
-        this.bsgCategories[id].normalizedName = normalizeName(this.bsgCategories[id].locale.en.name);
-        this.bsgCategories[id].enumName = catNameToEnum(this.bsgCategories[id].locale.en.name);
+        this.bsgCategories[id].normalizedName = normalizeName(this.kvData.locale.en[this.bsgCategories[id].name]);
+        this.bsgCategories[id].enumName = catNameToEnum(this.kvData.locale.en[this.bsgCategories[id].name]);
     
         this.addCategory(this.bsgCategories[id].parent_id);
     }
@@ -501,14 +494,11 @@ class UpdateItemCacheJob extends DataJob {
         }
         this.handbookCategories[id] = {
             id: id,
-            name: this.locales.en[id],
+            name: this.addTranslation(id),
             normalizedName: normalizeName(this.locales.en[id]),
             enumName: catNameToEnum(this.locales.en[id]),
             parent_id: null,
             child_ids: [],
-            locale: getTranslations({
-                name: id,
-            }, this.logger),
         };
     
         const category = this.handbook.Categories.find(cat => cat.Id === id);

--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -268,7 +268,7 @@ class UpdateItemCacheJob extends DataJob {
             const handbookItemId = itemData[key].types.includes('preset') ? itemData[key].properties.base_item_id : key;
             const handbookItem = this.handbook.Items.find(hbi => hbi.Id === handbookItemId);
             if (!handbookItem) {
-                this.logger.warn(`Item ${itemData[key].name} ${key} has no handbook entry`);
+                this.logger.warn(`Item ${this.locales.en[itemData[key].name]} ${key} has no handbook entry`);
             } else {
                 this.addHandbookCategory(handbookItem.ParentId);
                 let parent = this.handbookCategories[handbookItem.ParentId];
@@ -320,7 +320,7 @@ class UpdateItemCacheJob extends DataJob {
                 '5448bf274bdc2dfc2f8b456a', // secure container
             ];
             if (itemData[id].traderPrices.length === 0 && !ignoreCategories.includes(itemData[id].bsgCategoryId)) {
-                this.logger.warn(`No trader sell prices mapped for ${itemData[id].name} (${id}) with category id ${itemData[id].bsgCategoryId}`);
+                this.logger.warn(`No trader sell prices mapped for ${this.locales.en[itemData[id].name]} (${id}) with category id ${itemData[id].bsgCategoryId}`);
             }
         }
 
@@ -385,7 +385,7 @@ class UpdateItemCacheJob extends DataJob {
                 } else if (this.bsgItems[id]) {
                     //this.logger.log(`${conId} is probably disabled`);
                 } else {
-                    this.logger.log(`${item.name} ${item.id} could not categorize conflicting item id ${conId}`);
+                    this.logger.log(`${this.locales.en[item.name]} ${item.id} could not categorize conflicting item id ${conId}`);
                 }
             });
         }

--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -280,6 +280,8 @@ class UpdateItemCacheJob extends DataJob {
 
             // translations
             if (this.locales.en[`${key} Name`]) { 
+                itemData[key].name = this.addTranslation(`${key} Name`);
+                itemData[key].shortName = this.addTranslation(`${key} ShortName`);
                 itemData[key].description = this.addTranslation(`${key} Description`);
             } else if (this.presets[key]) {
                 for (const langCode in this.presets[key].locale) {
@@ -582,7 +584,7 @@ class UpdateItemCacheJob extends DataJob {
                 }
             }
             traderPrices.push({
-                name: trader.name,
+                name: this.locales.en[trader.name],
                 price: priceCUR,
                 currency: currency,
                 currencyItem: currencyId[currency],

--- a/src/tarkov-data-manager/jobs/update-maps.js
+++ b/src/tarkov-data-manager/jobs/update-maps.js
@@ -2,7 +2,6 @@ const remoteData = require('../modules/remote-data');
 const tarkovData = require('../modules/tarkov-data');
 const normalizeName = require('../modules/normalize-name');
 //const mapQueueTimes = require('../modules/map-queue-times');
-const { setLocales, getTranslations, addTranslations } = require('../modules/get-translation');
 const DataJob = require('../modules/data-job');
 const s3 = require('../modules/upload-s3');
 
@@ -14,19 +13,15 @@ class UpdateMapsJob extends DataJob {
 
     run = async () => {
         this.logger.log('Getting maps data...');
-        [this.locales, this.items, this.presets] = await Promise.all([
-            tarkovData.locales(),
+        [this.items, this.presets] = await Promise.all([
             remoteData.get(),
             this.jobManager.jobOutput('update-presets', this, true),
         ]);
-        setLocales(this.locales);
         this.bossLoadouts = {};
         this.processedBosses = {};
         const locations = await tarkovData.locations();
         this.s3Images = s3.getLocalBucketContents();
-        const maps = {
-            Map: [],
-        };
+        this.kvData.Map = [];
         this.logger.log('Processing maps...');
         for (const id in locations.locations) {
             const map = locations.locations[id];
@@ -37,7 +32,7 @@ class UpdateMapsJob extends DataJob {
             const mapData = {
                 id: id,
                 tarkovDataId: null,
-                name: this.locales.en[`${id} Name`],
+                name: this.addTranslation(`${id} Name`),
                 normalizedName: normalizeName(this.locales.en[`${id} Name`]),
                 nameId: map.Id,
                 description: this.locales.en[`${id} Description`],
@@ -90,7 +85,7 @@ class UpdateMapsJob extends DataJob {
                         name: locationName,
                         chance: Math.round((locationCount[locationName].count / locations.length) * 100) / 100,
                         spawnKey: locationCount[locationName].key,
-                        locale: getTranslations({name: (lang, langCode) => {
+                        name: this.addTranslation(locationCount[locationName].key, (lang, langCode) => {
                             if (lang[locationCount[locationName].key]) {
                                 return lang[locationCount[locationName].key];
                             }
@@ -99,7 +94,7 @@ class UpdateMapsJob extends DataJob {
                             }
                             this.logger.warn(`No translation found for spawn location ${locationCount[locationName].key}`);
                             return locationName;
-                        }}, this.logger),
+                        }),
                     });
                 }
                 if (spawn.BossEscortAmount !== '0') {
@@ -138,11 +133,9 @@ class UpdateMapsJob extends DataJob {
 
                 if (spawn.TriggerId) {
                     if (this.locales.en[spawn.TriggerId]) {
-                        bossData.spawnTrigger = this.locales.en[spawn.TriggerId];
-                        addTranslations(bossData.locale, {spawnTrigger: spawn.TriggerId}, this.logger);
+                        bossData.spawnTrigger = this.addTranslation(spawn.TriggerId);
                     } else if (spawn.TriggerId.includes('EXFIL')) {
-                        addTranslations(bossData.locale, {spawnTrigger: 'ExfilActivation'}, this.logger);
-                        bossData.spawnTrigger = 'Exfil Activation';
+                        bossData.spawnTrigger = this.addTranslation('ExfilActivation');
                     }
                 }
                 /*bossData.locale = getTranslations({
@@ -159,45 +152,38 @@ class UpdateMapsJob extends DataJob {
                 }*/
                 mapData.bosses.push(bossData);
             }
-            mapData.enemies = [...enemySet];
-            mapData.locale = getTranslations({
-                name: lang => {
-                    if (id === '59fc81d786f774390775787e' && lang.factory4_night) {
-                        return lang.factory4_night;
-                    }
-                    return lang[`${id} Name`];
-                },
-                description: `${id} Description`,
-                enemies: lang => {
-                    const enemies = new Set(mapData.enemies.map(enemy => {
-                        return this.getEnemyName(enemy, lang);
-                    }));
-                    return [...enemies];
+            mapData.enemies = this.addTranslation([...enemySet], (enemy, lang) => {
+                return this.getEnemyName(enemy, lang);
+            });
+            mapData.name = this.addTranslation(`${id} Name`, (lang) => {
+                if (id === '59fc81d786f774390775787e' && lang.factory4_night) {
+                    return lang.factory4_night;
                 }
-            }, this.logger);
-            mapData.name = mapData.locale.en.name;
-            mapData.normalizedName = normalizeName(mapData.name);
-            maps.Map.push(mapData);
-            this.logger.log(`✔️ ${mapData.name} ${id}`);
+                return lang[`${id} Name`];
+            }),
+            mapData.description = this.addTranslation(`${id} Description`),
+            mapData.normalizedName = normalizeName(this.kvData.locale.en[mapData.name]);
+            this.kvData.Map.push(mapData);
+            this.logger.log(`✔️ ${this.kvData.locale.en[mapData.name]} ${id}`);
         }
 
         //const queueTimes = await mapQueueTimes(maps.data, this.logger);
-        maps.Map = maps.Map.sort((a, b) => a.name.localeCompare(b.name)).map(map => {
+        this.kvData.Map = this.kvData.Map.sort((a, b) => a.name.localeCompare(b.name)).map(map => {
             return {
                 ...map,
                 //queueTimes: queueTimes[map.id]
             };
         });
-        this.logger.log(`Processed ${maps.Map.length} maps`);
+        this.logger.log(`Processed ${this.kvData.Map.length} maps`);
 
-        maps.MobInfo = this.processedBosses;
-        this.logger.log(`Processed ${Object.keys(maps.MobInfo).length} mobs`);
-        for (const mob of Object.values(maps.MobInfo)) {
-            this.logger.log(`✔️ ${mob.locale.en.name}`);
+        this.kvData.MobInfo = this.processedBosses;
+        this.logger.log(`Processed ${Object.keys(this.kvData.MobInfo).length} mobs`);
+        for (const mob of Object.values(this.kvData.MobInfo)) {
+            this.logger.log(`✔️ ${this.kvData.locale.en[mob.name]}`);
         }
 
-        await this.cloudflarePut(maps);
-        return maps;
+        await this.cloudflarePut();
+        return this.kvData;
     }
 
     isValidItem = (id) => {
@@ -224,7 +210,7 @@ class UpdateMapsJob extends DataJob {
         if (lang[enemy]) {
             return lang[enemy];
         }
-        if (enemy.includes('follower')) {
+        if (enemy.includes('follower') && !enemy.includes('BigPipe') && !enemy.includes('BirdEye')) {
             const nameParts = [];
             const guardTypePattern = /Assault|Security|Scout/;
             const bossKey = enemy.replace('follower', 'boss').replace(guardTypePattern, '');
@@ -352,16 +338,14 @@ class UpdateMapsJob extends DataJob {
         const bossData = this.bossLoadouts[bossKey];
         const bossInfo = {
             id: bossKey,
+            name: this.addTranslation(bossKey, (lang) => {
+                return this.getEnemyName(bossKey, lang);
+            }),
             normalizedName: normalizeName(this.getEnemyName(bossKey, this.locales.en)),
             imagePortraitLink: `https://${process.env.S3_BUCKET}/unknown-mob-portrait.webp`,
             imagePosterLink: `https://${process.env.S3_BUCKET}/unknown-mob-poster.webp`,
             equipment: [],
             items: [],
-            locale: getTranslations({
-                name: lang => {
-                    return this.getEnemyName(bossKey, lang);
-                }
-            }, this.logger),
         };
         const extensions = [
             'webp',
@@ -385,8 +369,8 @@ class UpdateMapsJob extends DataJob {
         bossInfo.health = Object.keys(bossData.health.BodyParts[0]).map(bodyPart => {
             return {
                 id: bodyPart,
+                bodyPart: this.addTranslation(bodyPart),
                 max: bossData.health.BodyParts[0][bodyPart].max,
-                locale: getTranslations({bodyPart: bodyPart}, this.logger),
             };
         });
         for (const slotName in bossData.inventory.equipment) {

--- a/src/tarkov-data-manager/jobs/update-quests.js
+++ b/src/tarkov-data-manager/jobs/update-quests.js
@@ -5,7 +5,6 @@ const got = require('got');
 
 const remoteData = require('../modules/remote-data');
 const tarkovData = require('../modules/tarkov-data');
-const { setLocales, getTranslations, addTranslations } = require('../modules/get-translation');
 const normalizeName = require('../modules/normalize-name');
 const DataJob = require('../modules/data-job');
 
@@ -22,20 +21,18 @@ class UpdateQuestsJob extends DataJob {
             responseType: 'json',
             resolveBodyOnly: true,
         });
-        [this.rawQuestData, this.items, this.locales, this.itemResults, this.missingQuests, this.changedQuests, this.removedQuests] = await Promise.all([
+        [this.rawQuestData, this.items, this.itemResults, this.missingQuests, this.changedQuests, this.removedQuests] = await Promise.all([
             tarkovData.quests(true).catch(error => {
                 this.logger.error('Error getting quests');
                 this.logger.error(error);
                 return tarkovData.quests(false);
             }),
             tarkovData.items(),
-            tarkovData.locales(),
             remoteData.get(),
             fs.readFile(path.join(__dirname, '..', 'data', 'missing_quests.json')).then(json => JSON.parse(json)),
             fs.readFile(path.join(__dirname, '..', 'data', 'changed_quests.json')).then(json => JSON.parse(json)),
             fs.readFile(path.join(__dirname, '..', 'data', 'removed_quests.json')).then(json => JSON.parse(json)),
         ]);
-        setLocales(this.locales);
         this.maps = await this.jobManager.jobOutput('update-maps', this);
         this.hideout = await this.jobManager.jobOutput('update-hideout', this);
         const traders = await this.jobManager.jobOutput('update-traders', this);
@@ -72,27 +69,25 @@ class UpdateQuestsJob extends DataJob {
             }
             const quest = this.missingQuests[questId];
             if (quests.Task.some(q => q.id === questId)) {
-                this.logger.warn(`Missing quest ${quest.name} ${quest.id} already exists...`);
+                this.logger.warn(`Missing quest ${this.locales.en[quest.name]} ${quest.id} already exists...`);
                 continue;
             }
             try {
                 this.logger.warn(`Adding missing quest ${quest.name} ${quest.id}...`);
-                quest.locale = getTranslations({name: `${questId} name`}, this.logger);
+                quest.name = this.addTranslation(`${questId} name`);
                 quest.wikiLink = `https://escapefromtarkov.fandom.com/wiki/${encodeURIComponent(this.locales.en[`${questId} name`].replaceAll(' ', '_'))}`;
                 for (const obj of quest.objectives) {
-                    obj.locale = getTranslations({description: obj.id}, this.logger);
+                    obj.description = this.addTranslation(obj.id);
                     if (obj.type.endsWith('QuestItem')) {
                         this.questItems[obj.item_id] = {
                             id: obj.item_id
                         };
                     }
                     if (obj.type === 'extract') {
-                        obj.locale = addTranslations(obj.locale, {exitStatus: lang => {
-                            return obj.exitStatus.map(stat => lang[`ExpBonus${stat}`]);
-                        }}, this.logger);
+                        obj.exitStatus = this.addTranslation(obj.exitStatus.map(stat => `ExpBonus${stat}`));
                     }
                     if (obj.type === 'shoot') {
-                        obj.locale = addTranslations(obj.locale, {target: obj.target}, this.logger);
+                        obj.target = this.addTranslation(obj.target);
                     }
                     this.addMapFromDescription(obj);
                 }
@@ -126,20 +121,24 @@ class UpdateQuestsJob extends DataJob {
         for (const tdQuest of this.tdQuests) {
             try {
                 if (tdQuest.gameId && this.removedQuests[tdQuest.gameId]) continue;
-                if (!this.tdMatched.includes(tdQuest.id)) {
-                    this.logger.warn(`Adding TarkovData quest ${tdQuest.title} ${tdQuest.id}...`);
-                    if (!this.tdTraders) {
-                        this.logger.log('Retrieving TarkovTracker traders.json...');
-                        this.tdTraders = (await got('https://github.com/TarkovTracker/tarkovdata/raw/master/traders.json', {
-                            responseType: 'json',
-                        })).body;
-                        this.logger.log('Retrieving TarkovTracker maps.json...');
-                        this.tdMaps = (await got('https://github.com/TarkovTracker/tarkovdata/raw/master/maps.json', {
-                            responseType: 'json',
-                        })).body;
-                    }
-                    quests.Task.push(this.formatTdQuest(tdQuest));
+                if (this.tdMatched.includes(tdQuest.id)) {
+                    continue;
                 }
+                if (tdQuest.gameId && quests.Task.some(t => t.id === tdQuest.gameId)) {
+                    continue;
+                }
+                this.logger.warn(`Adding TarkovData quest ${tdQuest.title} ${tdQuest.id}...`);
+                if (!this.tdTraders) {
+                    this.logger.log('Retrieving TarkovTracker traders.json...');
+                    this.tdTraders = (await got('https://github.com/TarkovTracker/tarkovdata/raw/master/traders.json', {
+                        responseType: 'json',
+                    })).body;
+                    this.logger.log('Retrieving TarkovTracker maps.json...');
+                    this.tdMaps = (await got('https://github.com/TarkovTracker/tarkovdata/raw/master/maps.json', {
+                        responseType: 'json',
+                    })).body;
+                }
+                quests.Task.push(this.formatTdQuest(tdQuest));
             } catch (error) {
                 this.logger.error('Error processing missing TarkovData quests');
                 this.logger.error(error);
@@ -201,7 +200,7 @@ class UpdateQuestsJob extends DataJob {
             quest.startMessageId = this.locales.en.quest[quest.id]?.startedMessageText;
             quest.successMessageId = this.locales.en.quest[quest.id]?.successMessageText;
             quest.failMessageId = this.locales.en.quest[quest.id]?.failMessageText;*/
-            quest.normalizedName = normalizeName(quest.name)+(quest.factionName !== 'Any' ? `-${normalizeName(quest.factionName)}` : '');
+            quest.normalizedName = normalizeName(this.locales.en[quest.name])+(quest.factionName !== 'Any' ? `-${normalizeName(quest.factionName)}` : '');
 
             const removeReqs = [];
             for (const req of quest.taskRequirements) {
@@ -343,11 +342,9 @@ class UpdateQuestsJob extends DataJob {
                 //questItems[id].backgroundColor = items[id]._props.BackgroundColor;
                 this.questItems[id].width = this.items[id]._props.Width;
                 this.questItems[id].height = this.items[id]._props.Height;
-                this.questItems[id].locale = getTranslations({
-                    name: `${id} Name`,
-                    shortName: `${id} ShortName`,
-                    description: `${id} Description`
-                }, this.logger);
+                this.questItems[id].name = this.addTranslation(`${id} Name`);
+                this.questItems[id].shortName = this.addTranslation(`${id} ShortName`);
+                this.questItems[id].description = this.addTranslation(`${id} Description`);
             }
             if (questItemMap.has(id)) {
                 const itemData = questItemMap.get(id);
@@ -360,12 +357,14 @@ class UpdateQuestsJob extends DataJob {
             } else {
                 this.logger.warn(`Quest item ${id} not found in DB`);
             }
-            this.questItems[id].normalizedName = normalizeName(this.questItems[id].locale.en.name);
+            this.questItems[id].normalizedName = normalizeName(this.locales.en[this.questItems[id].name]);
         }
 
         quests.QuestItem = this.questItems;
 
         quests.Quest = await this.jobManager.runJob('update-quests-legacy', {data: this.tdQuests, parent: this});
+
+        quests.locale = this.kvData.locale;
 
         await this.cloudflarePut(quests);
         this.logger.success(`Finished processing ${quests.Task.length} quests`);
@@ -517,11 +516,10 @@ class UpdateQuestsJob extends DataJob {
                 questData[rewardsType].offerUnlock.push(unlock);
             } else if (reward.type === 'Skill') {
                 const skillLevel = {
-                    name: this.locales.en[reward.target],
-                    level: parseInt(reward.value) / 100,
-                    locale: getTranslations({name: lang => {
+                    name: this.addTranslation(reward.target, (lang) => {
                         return lang[reward.target] || reward.target;
-                    }}, this.logger)
+                    }),
+                    level: parseInt(reward.value) / 100,
                 };
                 questData[rewardsType].skillLevelReward.push(skillLevel);
             } else if (reward.type === 'TraderUnlock') {
@@ -785,7 +783,7 @@ class UpdateQuestsJob extends DataJob {
         }
         const questData = {
             id: questId,
-            name: this.locales.en[`${questId} name`],
+            name: this.addTranslation(`${questId} name`),
             trader: quest.traderId,
             traderName: this.locales.en[`${quest.traderId} Nickname`],
             location_id: locationId,
@@ -843,7 +841,6 @@ class UpdateQuestsJob extends DataJob {
             tarkovDataId: undefined,
             factionName: 'Any',
             neededKeys: [],
-            locale: getTranslations({name: `${questId} name`}, this.logger)
         };
         for (const objective of quest.conditions.AvailableForFinish) {
             const obj = this.formatObjective(objective);
@@ -986,7 +983,6 @@ class UpdateQuestsJob extends DataJob {
                         newObj.locale_map = {};
                     }
                     newObj.locale_map.description = newObj.id;
-                    newObj.locale = getTranslations(newObj.locale_map, this.logger);
                     questData.objectives.push(newObj);
                     addedCount++;
                 }
@@ -1014,9 +1010,6 @@ class UpdateQuestsJob extends DataJob {
                 //this.logger.warn(JSON.stringify(this.changedQuests[questData.id].finishRewardsAdded), null, 4);
                 for (const rewardType in this.changedQuests[questData.id].finishRewardsAdded) {
                     for (const reward of this.changedQuests[questData.id].finishRewardsAdded[rewardType]) {
-                        if (reward.locale_map) {
-                            reward.locale = getTranslations(reward.locale_map, this.logger);
-                        }
                         questData.finishRewards[rewardType].push(reward);
                     }
                 }
@@ -1028,7 +1021,7 @@ class UpdateQuestsJob extends DataJob {
                     questData.finishRewards[rewardType] = this.changedQuests[questData.id].finishRewardsChanged[rewardType];
                     if (rewardType === 'skillLevelReward') {
                         for (const reward of questData.finishRewards[rewardType]) {
-                            reward.locale = getTranslations({name: reward.name}, this.logger);
+                            reward.name = this.addTranslation(reward.name);
                         }
                     }
                 }
@@ -1109,12 +1102,12 @@ class UpdateQuestsJob extends DataJob {
         }
         const obj = {
             id: objectiveId,
+            description: this.addTranslation(objectiveId),
             type: null,
             optional: optional,
             locationNames: [],
             map_ids: [],
             zoneKeys: [],
-            locale: getTranslations({description: objectiveId}, this.logger, false, logNotFound)
         };
         if (objective._parent === 'FindItem' || objective._parent === 'HandoverItem') {
             const targetItem = this.items[objective._props.target[0]];
@@ -1152,10 +1145,7 @@ class UpdateQuestsJob extends DataJob {
                     if (cond._parent === 'Shots') obj.shotType = 'hit';
                     //obj.bodyParts = [];
                     if (cond._props.bodyPart) {
-                        obj.bodyParts = cond._props.bodyPart;
-                        obj.locale = addTranslations(obj.locale, {bodyParts: lang => {
-                            return cond._props.bodyPart.map(part => lang[`QuestCondition/Elimination/Kill/BodyPart/${part}`]);
-                        }}, this.logger);
+                        obj.bodyParts = this.addTranslation(cond._props.bodyPart.map(part => `QuestCondition/Elimination/Kill/BodyPart/${part}`));
                     }
                     obj.usingWeapon = [];
                     obj.usingWeaponMods = [];
@@ -1206,25 +1196,18 @@ class UpdateQuestsJob extends DataJob {
                         obj.enemyHealthEffect = {
                             ...cond._props.enemyHealthEffects[0],
                             time: null,
-                            locale: getTranslations({
-                                bodyParts: lang => {
-                                    if (!cond._props.enemyHealthEffects[0].bodyParts) {
-                                        return undefined;
-                                    }
-                                    return cond._props.enemyHealthEffects[0].bodyParts.map(part => lang[`QuestCondition/Elimination/Kill/BodyPart/${part}`]);
-                                }, effects: lang => {
-                                    if (!cond._props.enemyHealthEffects[0].effects) {
-                                        return undefined;
-                                    }
-                                    return cond._props.enemyHealthEffects[0].effects.map(eff => {
-                                        if (eff === 'Stimulator') {
-                                            return lang['5448f3a64bdc2d60728b456a Name'];
-                                        }
-                                        return lang[eff];
-                                    });
-                                }
-                            }, this.logger),
                         };
+                        if (cond._props.enemyHealthEffects[0].bodyParts) {
+                            obj.bodyParts = this.addTranslation(cond._props.enemyHealthEffects[0].bodyParts.map(part => `QuestCondition/Elimination/Kill/BodyPart/${part}`));
+                        }
+                        if (cond._props.enemyHealthEffects[0].effects) {
+                            obj.effects = this.addTranslation(cond._props.enemyHealthEffects[0].effects.map(eff => {
+                                if (eff === 'Stimulator') {
+                                    return '5448f3a64bdc2d60728b456a Name';
+                                }
+                                return eff;
+                            }))
+                        }
                     }
                     let targetCode = cond._props.target;
                     if (cond._props.savageRole) {
@@ -1234,7 +1217,7 @@ class UpdateQuestsJob extends DataJob {
                         obj.timeFromHour = cond._props.daytime.from;
                         obj.timeUntilHour = cond._props.daytime.to;
                     }
-                    obj.locale = addTranslations(obj.locale, {target: lang => {
+                    obj.target = this.addTranslation(targetCode, (lang) => {
                         if (targetCode == 'followerBully') {
                             return `${lang['QuestCondition/Elimination/Kill/BotRole/bossBully']} ${lang['ScavRole/Follower']}`;
                         }
@@ -1250,7 +1233,7 @@ class UpdateQuestsJob extends DataJob {
                             name = targetCode;
                         }
                         return name;
-                    }}, this.logger);
+                    });
                 } else if (cond._parent === 'Location') {
                     for (const loc of cond._props.target) {
                         if (loc === 'develop') continue;
@@ -1263,13 +1246,10 @@ class UpdateQuestsJob extends DataJob {
                         }
                     }
                 } else if (cond._parent === 'ExitStatus') {
-                    obj.exitStatus = cond._props.status;
-                    obj.locale = addTranslations(obj.locale, {exitStatus: lang => {
-                        return cond._props.status.map(stat => lang[`ExpBonus${stat}`]);
-                    }}, this.logger);
+                    obj.exitStatus = this.addTranslation(cond._props.status.map(stat => `ExpBonus${stat}`));
                     obj.zoneNames = [];
                 } else if (cond._parent === 'ExitName') {
-                    obj.locale = addTranslations(obj.locale, {exitName: cond._props.exitName}, this.logger);
+                    obj.exitName = this.addTranslation(cond._props.exitName)
                     if (cond._props.exitName && obj.map_ids.length === 0) {
                         if (extractMap[cond._props.exitName]) {
                             obj.map_ids.push(extractMap[cond._props.exitName]);
@@ -1311,25 +1291,18 @@ class UpdateQuestsJob extends DataJob {
                         bodyParts: cond._props.bodyPartsWithEffects[0].bodyParts,
                         effects: cond._props.bodyPartsWithEffects[0].effects,
                         time: null,
-                        locale: getTranslations({
-                            bodyParts: lang => {
-                                if (!cond._props.bodyPartsWithEffects[0].bodyParts) {
-                                    return undefined;
-                                }
-                                return cond._props.bodyPartsWithEffects[0].bodyParts.map(part => lang[`QuestCondition/Elimination/Kill/BodyPart/${part}`]);
-                            }, effects: lang => {
-                                if (!cond._props.bodyPartsWithEffects[0].effects) {
-                                    return undefined;
-                                }
-                                return cond._props.bodyPartsWithEffects[0].effects.map(eff => {
-                                    if (eff === 'Stimulator') {
-                                        return lang['5448f3a64bdc2d60728b456a Name'];
-                                    }
-                                    return lang[eff];
-                                });
-                            }
-                        }, this.logger),
                     };
+                    if (cond._props.bodyPartsWithEffects[0].bodyParts) {
+                        obj.bodyParts = this.addTranslation(cond._props.bodyPartsWithEffects[0].bodyParts.map(part => `QuestCondition/Elimination/Kill/BodyPart/${part}`));
+                    }
+                    if (cond._props.bodyPartsWithEffects[0].effects) {
+                        obj.effects = this.addTranslation(cond._props.bodyPartsWithEffects[0].effects.map(eff => {
+                            if (eff === 'Stimulator') {
+                                return '5448f3a64bdc2d60728b456a Name';
+                            }
+                            return eff;
+                        }))
+                    }
                     if (cond._props.time) obj.healthEffect.time = cond._props.time;
                 } else if (cond._parent === 'UseItem') {
                     obj.useAny = cond._props.target.filter(id => this.itemMap[id]).reduce((allItems, current) => {
@@ -1392,9 +1365,8 @@ class UpdateQuestsJob extends DataJob {
         } else if (objective._parent === 'Skill') {
             obj.type = 'skill';
             obj.skillLevel = {
-                name: this.locales.en[objective._props.target],
+                name: this.addTranslation(objective._props.target),
                 level: objective._props.value,
-                locale: getTranslations({name: objective._props.target}, this.logger)
             };
         } else if (objective._parent === 'WeaponAssembly') {
             obj.type = 'buildWeapon';
@@ -1530,7 +1502,7 @@ class UpdateQuestsJob extends DataJob {
                 }
                 return reducedKeys;
             }, []);
-            addTranslations(obj.locale, {zoneNames: reducedZones}, this.logger);
+            obj.zoneNames = this.addTranslation(reducedZones);
         } else {
             delete obj.zoneKeys;
         }

--- a/src/tarkov-data-manager/jobs/update-trader-prices.js
+++ b/src/tarkov-data-manager/jobs/update-trader-prices.js
@@ -361,7 +361,7 @@ class UpdateTraderPricesJob extends DataJob {
     }
 
     getTraderByName = (traderName) => {
-        return this.traders.find(t => t.name.toLowerCase() === traderName.toLowerCase());
+        return this.traders.find(t => this.locales.en[t.name].toLowerCase() === traderName.toLowerCase());
     }
 }
 

--- a/src/tarkov-data-manager/modules/get-item-properties.js
+++ b/src/tarkov-data-manager/modules/get-item-properties.js
@@ -1,5 +1,3 @@
-const { setLocales, getTranslations } = require('./get-translation');
-
 let itemIds = false;
 let disabledItemIds = false;
 let job = false;
@@ -21,7 +19,6 @@ const setAll = async (options) => {
         },
         job: j => {
             job = j;
-            setLocales(j.locales);
         },
     };
     for (const key in options) {
@@ -108,7 +105,7 @@ const getSlots = (item) => {
             nameId: slot._name,
             required: slot._required,
             filters: getFilterConstraints(item, slot),
-            locale: getTranslations({name: (lang, code) => {
+            name: job.addTranslation(nameKey, (lang, code) => {
                 if (lang[nameKey]) {
                     return lang[nameKey].replace(/(?<!^|\s)\p{Lu}/gu, substr => {
                         return substr.toLowerCase();
@@ -119,7 +116,7 @@ const getSlots = (item) => {
                         return substr.toLowerCase();
                     });
                 }
-            }}, job.logger),
+            }),
         };
         if (missingTranslations.length > 0) job.logger.warn(`Could not find ${missingTranslations.join(', ')} label for ${nameKey} slot of ${item._id}`);
         return formattedSlot;
@@ -142,14 +139,8 @@ const getStimEffects = (item) => {
                 duration: buff.Duration,
                 value: buff.Value,
                 percent: !buff.AbsoluteValue,
-                locale: getTranslations({
-                    type: lang => {
-                        return buff.SkillName ? lang.Skill : lang[effectKey];
-                    },
-                    skillName: lang => {
-                        return buff.SkillName ? lang[buff.SkillName] : undefined;
-                    }
-                }, job.logger),
+                type: buff.SkillName ? job.addTranslation('Skill') : job.addTranslation(effectKey),
+                skillName: buff.SkillName ? job.addTranslation(buff.SkillName) : undefined
             };
             stimEffects.push(effect);
         }
@@ -222,10 +213,8 @@ const getItemProperties = async (item) => {
                 turnPenalty: parseInt(item._props.mousePenalty) / 100,
                 ergoPenalty: parseInt(item._props.weaponErgonomicPenalty),
                 armor_material_id: item._props.ArmorMaterial,
-                locale: getTranslations({
-                    zones: item._props.armorZone,
-                    armorType: item._props.ArmorType,
-                }),
+                zones: job.addTranslation(item._props.armorZone),
+                armorType: job.addTranslation(item._props.ArmorType)
             };
         }
     } else if (item._parent === '5448e53e4bdc2d60728b4567') {
@@ -290,17 +279,13 @@ const getItemProperties = async (item) => {
                 ricochetY: item._props.RicochetParams.y,
                 ricochetZ: item._props.RicochetParams.z,
                 armor_material_id: item._props.ArmorMaterial,
-                locale: getTranslations({
-                    headZones: lang => {
-                        return item._props.headSegments.map(key => {
-                            if (key === 'LowerNape') {
-                                key = key.toLowerCase();
-                            }
-                            return lang[`HeadSegment/${key}`];
-                        });
-                    },
-                    armorType: item._props.ArmorType,
-                }, job.logger),
+                headZones: job.addTranslation(item._props.headSegments.map(key => {
+                    if (key === 'LowerNape') {
+                        key = key.toLowerCase();
+                    }
+                    key;
+                })),
+                armorType: job.addTranslation(item._props.ArmorType),
             };
             if (hasCategory(item, ['5a341c4086f77401f2541505', '5a341c4686f77469e155819e'])) {
                 properties.propertiesType = 'ItemPropertiesHelmet';
@@ -347,11 +332,7 @@ const getItemProperties = async (item) => {
             }).reduce((previousValue, currentValue) => {
                 return currentValue.id;
             }, null),
-            locale: getTranslations({fireModes: lang => {
-                return item._props.weapFireType.map(mode => {
-                    return lang[mode];
-                });
-            }}, job.logger),
+            fireModes: job.addTranslation(item._props.weapFireType),
         };
     } else if (item._parent === '5a2c3a9486f774688b05e574') {
         // night vision

--- a/src/tarkov-data-manager/modules/kv-delta.js
+++ b/src/tarkov-data-manager/modules/kv-delta.js
@@ -8,6 +8,7 @@ const ignoreTypes = [
     'updated',
     'data',
     'expiration',
+    'locale',
     'ItemType',
     'LanguageCode',
 ];
@@ -25,7 +26,7 @@ const typesQueries = {
     FleaMarket: ['fleaMarket'],
     HideoutStation: ['hideoutStations'],
     historicalItemPricePoint: ['historicalItemPrices'],
-    Item: ['items', 'itemsByIDs', 'itemsByType', 'itemsByName', 'itemByNormalizedName', 'itemsByBsgCategory'],
+    Item: ['items', 'itemsByIDs', 'itemsByType', 'itemsByName', 'itemByNormalizedName', 'itemsByBsgCategoryId'],
     ItemCategory: ['itemCategories', 'handbookCategories'],
     Map: ['maps'],
     MobInfo: ['bosses'],
@@ -38,6 +39,19 @@ const typesQueries = {
     Quest: ['quests'],
     TraderResetTime: ['traderResetTimes'],
 };
+
+const localeTypes = [
+    'ArmorMaterial',
+    'FleaMarket',
+    'HideoutStation',
+    'Item',
+    'ItemCategory',
+    'Map',
+    'MobInfo',
+    'QuestItem',
+    'Task',
+    'Trader',
+];
 
 const linkedTypes = {
     TraderCashOffer: ['ItemPrice'],
@@ -88,8 +102,19 @@ module.exports = async (outputFile, logger) => {
     try {
         newData = JSON.parse(fs.readFileSync(`./dumps/${outputFile}.json`));
         purgeData.updated =  new Date(newData.updated);
+        let localeChanged = false;
+        if (newData.locale) {
+            if (JSON.stringify(oldData.locale) !== JSON.stringify(newData.locale)) {
+                localeChanged = true;
+            }
+        }
         for (const dataType in oldData) {
             if (ignoreTypes.includes(dataType)) {
+                continue;
+            }
+            if (localeChanged && localeTypes[dataType]) {
+                addTypePurge(purgeData, dataType);
+                addQueryPurge(purgeData, dataType);
                 continue;
             }
             const oldD = oldData[dataType];

--- a/src/tarkov-data-manager/package.json
+++ b/src/tarkov-data-manager/package.json
@@ -11,7 +11,8 @@
     "dev": "node -r dotenv/config --trace-warnings index.js",
     "start": "node --max-old-space-size=3000 index.js",
     "job": "node -r dotenv/config --trace-warnings test-job.js",
-    "put-kvs": "node -r dotenv/config --trace-warnings populate-kvs.js"
+    "put-kvs": "node -r dotenv/config --trace-warnings populate-kvs.js",
+    "kv-locale": "node -r dotenv/config --trace-warnings ./scripts/generate-kv-locale.js"
   },
   "keywords": [],
   "author": "",

--- a/src/tarkov-data-manager/scripts/generate-kv-locale.js
+++ b/src/tarkov-data-manager/scripts/generate-kv-locale.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+
+if (process.env.NODE_ENV !== 'production') {
+    const dotenv = require("dotenv");
+    dotenv.config({path : './config.env'});
+    dotenv.config({path : './creds.env'});
+    process.env.NODE_ENV = 'dev';
+    process.env.VERBOSE_LOGS = 'true';
+}
+
+const { connection, jobComplete } = require('../modules/db-connection');
+const { jobOutput } = require('../jobs');
+
+const localeJobs = [
+    'update-traders',
+    'update-item-cache',
+    'update-hideout',
+    'update-maps',
+    'update-quests',
+];
+
+(async () => {
+    connection.keepAlive = true;
+    const locales = {};
+    for (const job of localeJobs) {
+        try {
+            const output = await jobOutput(job, false, true);
+            for (const langCode in output.locale) {
+                if (!locales[langCode]) {
+                    locales[langCode] = {};
+                }
+                for (const key in output.locale[langCode]) {
+                    locales[langCode][key] = output.locale[langCode][key];
+                }
+            }
+        } catch (error) {
+            console.log(`Error running ${job} job`, error);
+        }
+    }
+    fs.writeFileSync('./dumps/kv_locale_en.json', JSON.stringify(locales.en, null, 4));
+    connection.keepAlive = false;
+    jobComplete();
+})();


### PR DESCRIPTION
Should be deployed to production in conjunction with the matching API PR. Changes the way translations are handled to save space and make it easier to get a list of which strings we use.