### PR TITLE
Remove exclusions from trader buys

### DIFF
--- a/src/tarkov-data-manager/modules/data-map.js
+++ b/src/tarkov-data-manager/modules/data-map.js
@@ -39,10 +39,7 @@ module.exports = {
                 categories: [],
             },
             prohibitedAdded: {
-                ids: [
-                    '5a33a8ebc4a282000c5a950d',
-                    '5644bd2b4bdc2d3b4c8b4572',
-                ],
+                ids: [],
                 categories: [],
             }
         }


### PR DESCRIPTION
Bug is fixed that prevented traders from buying items they should be able to, so no longer necessary to manually exclude items that they can buy.