### PR TITLE
Work with fewer db indexes

### DIFF
--- a/src/tarkov-data-manager/index.js
+++ b/src/tarkov-data-manager/index.js
@@ -1822,7 +1822,13 @@ app.post('/wipes', async (req, res) => {
     }
     try {
         console.log(`creating wipe: ${req.body.start_date} ${req.body.version}`);
-        await query('INSERT INTO wipe (start_date, version) VALUES (?, ?)', [req.body.start_date, req.body.version]);
+        const result = await query('INSERT INTO wipe (start_date, version) VALUES (?, ?)', [req.body.start_date, req.body.version]);
+        let lastPriceId = 0;
+        const lastPrice = await query('SELECT id FROM price_data ORDER BY id DESC LIMIT 1');
+        if (lastPrice.length > 0) {
+            lastPriceId = lastPrice[0].id;
+        }
+        await query('UPDATE wipe SET cuttoff_price_id=? WHERE id=?', [lastPriceId, result.insertId]);
         response.message = `Created wipe ${req.body.start_date} ${req.body.version}`;
     } catch (error) {
         response.errors.push(error.message);

--- a/src/tarkov-data-manager/jobs/check-scans.js
+++ b/src/tarkov-data-manager/jobs/check-scans.js
@@ -47,8 +47,8 @@ class CheckScansJob extends DataJob {
 
             //logger.log(JSON.stringify(scanner));
             // Db timestamps are off so we add an hour
-            let lastScan = new Date(scanner.last_scan.setTime(scanner.last_scan.getTime() + 3600000));
-            const traderLastScan = new Date(scanner.trader_last_scan.setTime(scanner.trader_last_scan.getTime() + 3600000));
+            let lastScan = new Date(scanner.last_scan?.setTime(scanner.last_scan.getTime() + 3600000));
+            const traderLastScan = new Date(scanner.trader_last_scan?.setTime(scanner.trader_last_scan.getTime() + 3600000));
             if (traderLastScan > lastScan) {
                 lastScan = traderLastScan;
             }

--- a/src/tarkov-data-manager/jobs/clear-checkouts.js
+++ b/src/tarkov-data-manager/jobs/clear-checkouts.js
@@ -36,7 +36,7 @@ class ClearCheckoutsJob extends DataJob {
                     SET
                         trader_checkout_scanner_id = NULL
                     WHERE
-                    trader_checkout_scanner_id = ?;
+                        trader_checkout_scanner_id = ?;
                 `, [scanner.id]);
             }
         }

--- a/src/tarkov-data-manager/jobs/update-item-cache.js
+++ b/src/tarkov-data-manager/jobs/update-item-cache.js
@@ -53,8 +53,6 @@ class UpdateItemCacheJob extends DataJob {
                     item_id
                 FROM
                     (SELECT * FROM price_data WHERE id > ${lastWipe.cuttoff_price_id}) prices
-                WHERE
-                    timestamp > ?
                 GROUP BY
                     item_id
             ) b
@@ -62,7 +60,7 @@ class UpdateItemCacheJob extends DataJob {
                 a.timestamp = b.timestamp
             GROUP BY
                 item_id, timestamp, price;
-        `, [lastWipe.start_date]).then(results => {
+        `).then(results => {
             this.logger.timeEnd('last-low-price-query');
             return results;
         });

--- a/src/tarkov-data-manager/modules/get-item-properties.js
+++ b/src/tarkov-data-manager/modules/get-item-properties.js
@@ -469,6 +469,11 @@ const getItemProperties = async (item) => {
             stabDamage: item._props.knifeHitStabDam,
             hitRadius: item._props.knifeHitRadius
         };
+    } else if (item._parent === '5645bcb74bdc2ded0b8b4578') {
+        properties = {
+            propertiesType: 'ItemPropertiesHeadphone',
+            hearingRangeModifier: item._props.RolloffMultiplier,
+        };
     } else if (item._props.MaxResource) {
         properties = {
             propertiesType: 'ItemPropertiesResource',

--- a/src/tarkov-data-manager/modules/scanner-api.js
+++ b/src/tarkov-data-manager/modules/scanner-api.js
@@ -665,7 +665,7 @@ const releaseItem = async (options) => {
             if (setLastScan) {
                 query(`
                     UPDATE scanner
-                    SET last_scan = NOW()
+                    SET ${trader}last_scan = NOW()
                     WHERE id = ?
                 `, [options.scanner.id]);
             }


### PR DESCRIPTION
This should be deployed when the ferwer-indexes planetscale branch is deployed. Then testing should be done to ensure things are working properly during the planetscale rollback window. If not working and unable to fix within the db undo window, the db deploy should be reversed and we should `.deploy main` here.