### PR TITLE
Use automatic timezone adjustment for check scans

### DIFF
--- a/src/tarkov-data-manager/jobs/update-quests.js
+++ b/src/tarkov-data-manager/jobs/update-quests.js
@@ -228,6 +228,7 @@ class UpdateQuestsJob extends DataJob {
 
             const earlierTasks = new Set();
             const addEarlier = (id) => {
+                earlierTasks.add(id);
                 quests.Task.find(q => q.id === id).taskRequirements.map(req => req.task).forEach(reqId => {
                     earlierTasks.add(reqId);
                     addEarlier(reqId);
@@ -236,7 +237,6 @@ class UpdateQuestsJob extends DataJob {
             const requiredIds = quest.taskRequirements.map(req => req.task);
             for (const reqId of requiredIds) {
                 quests.Task.find(q => q.id === reqId).taskRequirements.forEach(req => {
-                    earlierTasks.add(req.task);
                     addEarlier(req.task);
                 });
             }

--- a/src/tarkov-data-manager/jobs/update-quests.js
+++ b/src/tarkov-data-manager/jobs/update-quests.js
@@ -233,13 +233,14 @@ class UpdateQuestsJob extends DataJob {
                     addEarlier(reqId);
                 });
             };
-            const required = quest.taskRequirements.map(req => req.task);
-            for (const reqId of required) {
+            const requiredIds = quest.taskRequirements.map(req => req.task);
+            for (const reqId of requiredIds) {
                 quests.Task.find(q => q.id === reqId).taskRequirements.forEach(req => {
+                    earlierTasks.add(req.task);
                     addEarlier(req.task);
                 });
             }
-            for (const reqId of required) {
+            for (const reqId of requiredIds) {
                 if (earlierTasks.has(reqId)) {
                     //const requiredTask = quests.Task.find(q => q.id === reqId);
                     //this.logger.warn(`${this.locales.en[quest.name]} ${quest.id} required task ${this.locales.en[requiredTask.name]} ${requiredTask.id} is a precursor to another required task`);


### PR DESCRIPTION
Checking for missing scans used to rely on a manual timezone adjustment for the date in the database and the time used by the data manager system. This wasn't ideal as that offset could change depending on hosting and also during testing.