### PR TITLE
Start and Stop workflows

### DIFF
--- a/.github/workflows/start-vm.yml
+++ b/.github/workflows/start-vm.yml
@@ -1,0 +1,22 @@
+name: start-vm
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restart-vm:
+    runs-on: ubuntu-latest
+    environment: production-secrets
+
+    steps:
+      - name: azure login
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # pin@v2.1.1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: start vm
+        uses: azure/CLI@965c8d7571d2231a54e321ddd07f7b10317f34d9 # pin@v2.0.0
+        with:
+          azcliversion: 2.50.0
+          inlineScript: |
+            az vm start --resource-group tdm_rg --name tdm_vm

--- a/.github/workflows/start-vm.yml
+++ b/.github/workflows/start-vm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  restart-vm:
+  start-vm:
     runs-on: ubuntu-latest
     environment: production-secrets
 

--- a/.github/workflows/stop-vm.yml
+++ b/.github/workflows/stop-vm.yml
@@ -1,0 +1,24 @@
+# this workflow *can* take up to 10 minutes to fully shut down the VM
+
+name: stop-vm
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restart-vm:
+    runs-on: ubuntu-latest
+    environment: production-secrets
+
+    steps:
+      - name: azure login
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # pin@v2.1.1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: stop vm
+        uses: azure/CLI@965c8d7571d2231a54e321ddd07f7b10317f34d9 # pin@v2.0.0
+        with:
+          azcliversion: 2.50.0
+          inlineScript: |
+            az vm stop --resource-group tdm_rg --name tdm_vm

--- a/.github/workflows/stop-vm.yml
+++ b/.github/workflows/stop-vm.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  restart-vm:
+  stop-vm:
     runs-on: ubuntu-latest
     environment: production-secrets
 

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v9.1.0
+        uses: github/branch-deploy@v9
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
This pull request adds two new workflows that can be run by members of this repository with `write` permissions. These workflows are available from the `actions` tab on GitHub and allow for users to **start** or **stop** the tarkov-data-manager (TDM) VM. It should be noted that the `stop` workflow can take up to 10 minutes to actually complete. If the stop workflow completes in less than 1 minute, it is probably a lie. You should check the [status page](https://status.tarkov.dev/status/the-hideout) or try to manually access the VM (either via ssh or the web UI) to actually confirm if it has stopped or not.

On the flip side, the `start` workflow should only take a minute or two to fully boot the VM back up.

cc: @Razzmatazzz