### PR TITLE
Allow pve trader scan

### DIFF
--- a/src/tarkov-data-manager/jobs/check-scanners.mjs
+++ b/src/tarkov-data-manager/jobs/check-scanners.mjs
@@ -11,17 +11,17 @@ class CheckScansJob extends DataJob {
     }
 
     async run() {
-        const [services, scanners, activeTraderScan] = await Promise.all([
+        const [services, scanners, activeTraderScans] = await Promise.all([
             tarkovDevData.status().then(status => status.services).catch(error => {
                 this.logger.error(`Error getting EFT services status: ${error.message}`);
                 return [];
             }),
             this.query(`
-                select scanner.id, name, last_scan, trader_last_scan, pve_last_scan, username, scanner.flags, scanner_user.flags as user_flags, disabled 
+                select scanner.id, name, last_scan, trader_last_scan, pve_last_scan, pve_trader_last_scan, username, scanner.flags, scanner_user.flags as user_flags, disabled 
                 from scanner 
                 left join scanner_user on scanner_user.id = scanner.scanner_user_id
             `),
-            scannerApi.currentTraderScan(),
+            scannerApi.currentTraderScans(),
         ]);
 
         const tradingService = services.find(s => s.name === 'Trading');
@@ -39,7 +39,7 @@ class CheckScansJob extends DataJob {
                     prefix = 'pve_';
                 }
                 if (scanner[`${prefix}last_scan`]?.getTime() ?? 0 < scanCutoff) {
-                    this.logger.log(`${scanner.name} hasn't scanned ${gameMode.name} player prices ${dateNow.toRelative({ base: DateTime.fromJSDate(scanner.last_scan) })}; releasing any batches`);
+                    this.logger.log(`${scanner.name} hasn't scanned ${gameMode.name} player prices ${dateNow.toRelative({ base: DateTime.fromJSDate(scanner[`${prefix}last_scan`]) })}; releasing any batches`);
                     this.query(`
                         UPDATE
                             item_data
@@ -48,24 +48,25 @@ class CheckScansJob extends DataJob {
                         WHERE
                             ${prefix}checkout_scanner_id = ?;
                     `, [scanner.id]).catch(error => {
-                        this.logger.error(`Error clearing player batches for ${scanner.name}: ${error.message}`);
+                        this.logger.error(`Error clearing  ${gameMode.name} player batches for ${scanner.name}: ${error.message}`);
                     });
                 }
-            }
-            if (scanner.trader_last_scan?.getTime() < scanCutoff) {
-                this.logger.log(`${scanner.name} hasn't scanned trader prices ${dateNow.toRelative({ base: DateTime.fromJSDate(scanner.trader_last_scan) })}; releasing any batches`);
-                this.query(`
-                    UPDATE
-                        item_data
-                    SET
-                        trader_checkout_scanner_id = NULL
-                    WHERE
-                        trader_checkout_scanner_id = ?;
-                `, [scanner.id]).catch(error => {
-                    this.logger.error(`Error clearing trader batches for ${scanner.name}: ${error.message}`);
-                });
-                if (activeTraderScan?.scanner_id === scanner.id) {
-                    scannerApi.setTraderScanScanner(null);
+                if (scanner[`${prefix}_trader_last_scan`]?.getTime() < scanCutoff) {
+                    this.logger.log(`${scanner.name} hasn't scanned ${gameMode.name} trader prices ${dateNow.toRelative({ base: DateTime.fromJSDate(scanner[`${prefix}_trader_last_scan`]) })}; releasing any batches`);
+                    this.query(`
+                        UPDATE
+                            item_data
+                        SET
+                            trader_checkout_scanner_id = NULL
+                        WHERE
+                            trader_checkout_scanner_id = ?;
+                    `, [scanner.id]).catch(error => {
+                        this.logger.error(`Error clearing ${gameMode.name} trader batches for ${scanner.name}: ${error.message}`);
+                    });
+                    const activeTraderScan = activeTraderScans.find(s => s.game_mode === gameMode.value);
+                    if (activeTraderScan?.scanner_id === scanner.id) {
+                        scannerApi.setTraderScanScanner(gameMode.name, null);
+                    }
                 }
             }
 

--- a/src/tarkov-data-manager/jobs/start-trader-scan.mjs
+++ b/src/tarkov-data-manager/jobs/start-trader-scan.mjs
@@ -9,20 +9,20 @@ class StartTraderScanJob extends DataJob {
 
     async run() {
         this.logger.log('Starting trader scan...');
-        if (await scannerApi.currentTraderScan()) {
+        if (await scannerApi.currentTraderScan('regular')) {
             this.logger.log('Trader scan already in progress');
         } else {
-            await scannerApi.startTraderScan();
+            await scannerApi.startTraderScan('regular');
         }
 
-        const traderScan = await scannerApi.currentTraderScan();
+        const traderScan = await scannerApi.currentTraderScan('regular');
         if (!traderScan.scanner_name) {
             for (const scanner of webSocketServer.launchedScanners()) {
                 if (scanner.settings.scanStatus !== 'idle' || scanner.settings.scanMode !== 'auto') {
                     continue;
                 }
                 this.logger.log(`Starting ${scanner.name}`);
-                await scannerApi.setTraderScanScanner(scanner.name);
+                await scannerApi.setTraderScanScanner('regular', scanner.name);
                 //await webSocketServer.sendCommand(scanner.name, 'changeSetting', {name: 'offersFrom', value: 1});
                 await webSocketServer.sendCommand(scanner.name, 'resume');
                 break;

--- a/src/tarkov-data-manager/jobs/update-barters.mjs
+++ b/src/tarkov-data-manager/jobs/update-barters.mjs
@@ -95,6 +95,8 @@ class UpdateBartersJob extends DataJob {
                 trader_offer_scan 
             WHERE 
                 ended IS NOT NULL 
+            AND
+                game_mode = 0
             ORDER BY 
                 id DESC LIMIT 1
         `).then(result => {
@@ -110,6 +112,8 @@ class UpdateBartersJob extends DataJob {
                 trader_offers 
             WHERE 
                 last_scan >= ?
+            AND
+                game_mode = 0
         `, [lastOfferScan.started]);
         this.offerRequirements = await this.query(`SELECT * FROM trader_offer_requirements`);
         for (const offer of offers) {

--- a/src/tarkov-data-manager/jobs/update-trader-prices.mjs
+++ b/src/tarkov-data-manager/jobs/update-trader-prices.mjs
@@ -64,6 +64,8 @@ class UpdateTraderPricesJob extends DataJob {
                 trader_offer_scan 
             WHERE 
                 ended IS NOT NULL 
+            AND
+                game_mode = 0
             ORDER BY 
                 id DESC LIMIT 1
         `).then(result => {
@@ -79,6 +81,8 @@ class UpdateTraderPricesJob extends DataJob {
                 trader_offers 
             WHERE 
                 last_scan >= ?
+            AND
+                game_mode = 0
         `, [lastOfferScan.started]);
         this.offerRequirements = await this.query(`SELECT * FROM trader_offer_requirements`);
         this.getCurrencyValues(offers);

--- a/src/tarkov-data-manager/modules/get-item-properties.js
+++ b/src/tarkov-data-manager/modules/get-item-properties.js
@@ -145,8 +145,13 @@ const getArmorSlots = (item) => {
             id: slotInfo._id,
             nameId: slotName,
         };
+        const zones = [
+            ...slotInfo.armorColliders.map(collider => `Collider Type ${collider}`),
+            ...slotInfo.armorPlateColliders.map(collider => `Armor Zone ${collider}`),
+        ];
         if (slotInfo.locked) {
             const plateItem = job.bsgItems[slotInfo.Plate];
+            newSlot.name = job.addTranslation(plateItem._props.Name),
             newSlot.bluntThroughput = plateItem._props.BluntThroughput,
             newSlot.class = parseInt(plateItem._props.armorClass),
             newSlot.durability = parseInt(plateItem._props.Durability),
@@ -155,7 +160,7 @@ const getArmorSlots = (item) => {
             newSlot.turnPenalty = parseFloat(plateItem._props.mousePenalty) / 100,
             newSlot.ergoPenalty = parseFloat(plateItem._props.weaponErgonomicPenalty) / 100,
             newSlot.armor_material_id = plateItem._props.ArmorMaterial,
-            newSlot.zones = job.addTranslation(slotInfo.armorColliders.map(collider => `Collider Type ${collider}`)),
+            newSlot.zones = job.addTranslation(zones),
             newSlot.armorType = job.addTranslation(plateItem._props.ArmorType, (lang) => {
                 if (plateItem._props.ArmorType !== 'None') {
                     return lang[plateItem._props.ArmorType];
@@ -166,7 +171,7 @@ const getArmorSlots = (item) => {
             });
             newSlot.baseValue = job.credits[slotInfo.Plate];
         } else {
-            newSlot.zones = job.addTranslation(slotInfo.armorPlateColliders.map(collider => `Armor Zone ${collider}`));
+            newSlot.zones = job.addTranslation(zones);
             //newSlot.defaultPlate = slotInfo.Plate;
             newSlot.allowedPlates = slotInfo.Filter;
         }

--- a/src/tarkov-data-manager/modules/get-item-properties.js
+++ b/src/tarkov-data-manager/modules/get-item-properties.js
@@ -246,7 +246,7 @@ const getArmorClass = (item) => {
 
 const getArmorDurability = (item) => {
     if (!item._props.Slots) {
-        return 0;
+        return item._props.Durability ?? 0;
     }
     return item._props.Slots.reduce((armorDurability, slot) => {
         const plateId = slot._props.filters[0].Plate;

--- a/src/tarkov-data-manager/modules/get-item-properties.js
+++ b/src/tarkov-data-manager/modules/get-item-properties.js
@@ -245,7 +245,7 @@ const getArmorClass = (item) => {
 };
 
 const getArmorDurability = (item) => {
-    if (!item._props.Slots) {
+    if (!item._props.Slots?.length) {
         return item._props.Durability ?? 0;
     }
     return item._props.Slots.reduce((armorDurability, slot) => {

--- a/src/tarkov-data-manager/modules/get-item-properties.js
+++ b/src/tarkov-data-manager/modules/get-item-properties.js
@@ -151,7 +151,7 @@ const getArmorSlots = (item) => {
         ];
         if (slotInfo.locked) {
             const plateItem = job.bsgItems[slotInfo.Plate];
-            newSlot.name = job.addTranslation(plateItem._props.Name),
+            //newSlot.name = job.addTranslation(plateItem._props.Name),
             newSlot.bluntThroughput = plateItem._props.BluntThroughput,
             newSlot.class = parseInt(plateItem._props.armorClass),
             newSlot.durability = parseInt(plateItem._props.Durability),

--- a/src/tarkov-data-manager/modules/scanner-http-api.mjs
+++ b/src/tarkov-data-manager/modules/scanner-http-api.mjs
@@ -140,7 +140,7 @@ const scannerHttpApi = {
                 response = {
                     errors: [],
                     warnings: [],
-                    data: !!await scannerApi.currentTraderScan(),
+                    data: !!await scannerApi.currentTraderScan(options.sessionMode ?? 'regular'),
                 };
             }
             if (resource === 'offers') {


### PR DESCRIPTION
Add framework to eventually allow scanning PVE trader prices. Not currently enabled as prices are not different between the game modes.

Also fixes zones not properly showing for all armor slots.