### PR TITLE
Use price_historical table to optimize jobs

### DIFF
--- a/src/tarkov-data-manager/jobs/update-historical-prices.mjs
+++ b/src/tarkov-data-manager/jobs/update-historical-prices.mjs
@@ -57,13 +57,12 @@ class UpdateHistoricalPricesJob extends DataJob {
             this.logger.time('historical-prices-query');
             const historicalPriceData = await this.batchQuery(`
                 SELECT
-                    item_id, timestamp, MIN(price) AS price_min, AVG(price) AS price_avg
+                    item_id, timestamp, price_min, price_avg, offer_count
                 FROM
-                    price_data
+                    price_historical
                 WHERE
                     timestamp > ? AND
                     game_mode = ?
-                GROUP BY item_id, timestamp
                 ORDER BY timestamp, item_id
             `, [dateCutoff, gameMode.value], (batchResult, offset) => {
                 if (batchResult.length === 0 && offset === 0) {
@@ -81,6 +80,7 @@ class UpdateHistoricalPricesJob extends DataJob {
                 itemPriceData[row.item_id].push({
                     priceMin: row.price_min,
                     price: Math.round(row.price_avg),
+                    offerCount: row.offer_count,
                     timestamp: row.timestamp.getTime(),
                 });
             }

--- a/src/tarkov-data-manager/jobs/update-item-cache.mjs
+++ b/src/tarkov-data-manager/jobs/update-item-cache.mjs
@@ -62,7 +62,6 @@ class UpdateItemCacheJob extends DataJob {
             
         const priceFields = [
             'lastLowPrice',
-            'lastLowAvgPrice',
             'avg24hPrice',
             'low24hPrice',
             'high24hPrice',

--- a/src/tarkov-data-manager/modules/data-job.mjs
+++ b/src/tarkov-data-manager/modules/data-job.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { setMaxListeners } from 'node:events';
 
 import  { EmbedBuilder } from 'discord.js';
 import { DateTime } from 'luxon';
@@ -102,6 +103,7 @@ class DataJob {
             this.logger.parentLogger = options.parent.logger;
         }
         this.abortController = new AbortController();
+        setMaxListeners(17, this.abortController.signal);
         this.startDate = new Date();
         this.kvData = {};
         this.jobSummary = {


### PR DESCRIPTION
Almost a month ago, I added the `price_historical` table to the DB. This table acts as a summary each time a scanned group of prices is submitted for an item. Each row of the `price_historical` table contains the lowest price of that scan, the average price of that scan, and the number of offers on the flea for that item. When scanned prices are added to the `price_data` table, a corresponding row is created in the `price_historical` table. As with the detailed price table, the data in the `price_historical` table exists for a month before being purged. While this results in some duplication of data, it improves operations in significant ways.

First, we were updating historical prices by querying directly from the detailed prices table. This worked well enough when there was data from a previous run of the historical prices job available, which allowed the job to only query prices after the date of the newest price in that data. However, if the job didn't have previous data available and had to start from scratch, the job and/or the SQL server would choke and be unable to complete the job. With a dedicated `price_historical` table, it's now trivial to run this job, even from scratch. As an added benefit, we can also now include the offer count in the historical price data.

Second, getting the last low item price currently involves a query of detailed item prices that takes a long time for the SQL server to perform. It's much less computationally intensive to just get the last low price from the much smaller `price_historical` table, which speeds up the query.