### PR TITLE
Include offer count in archived prices

### DIFF
--- a/src/tarkov-data-manager/jobs/archive-prices.mjs
+++ b/src/tarkov-data-manager/jobs/archive-prices.mjs
@@ -69,7 +69,7 @@ class ArchivePricesJob extends DataJob {
                 const insertStart = new Date();
                 await this.query(`
                     INSERT INTO price_archive
-                        (item_id, price_date, price_min, price_avg, offer_count_min, offer_count_avg game_mode)
+                        (item_id, price_date, price_min, price_avg, offer_count_min, offer_count_avg, game_mode)
                     VALUES
                         ${Object.keys(itemPrices).map(() => '(?, ?, ?, ?, ?, ?, ?)').join(', ')}
                     ON DUPLICATE KEY UPDATE

--- a/src/tarkov-data-manager/jobs/archive-prices.mjs
+++ b/src/tarkov-data-manager/jobs/archive-prices.mjs
@@ -14,8 +14,9 @@ class ArchivePricesJob extends DataJob {
         cutoff.setUTCHours(0, 0, 0, 0);
 
         // archive max_days_per_run number of days
-        for (let i = 0; i < max_days_per_run; i++) {
-            for (const gameMode of this.gameModes) {
+       for (const gameMode of this.gameModes) {
+            let foundPrices = true;
+            for (let i = 0; i < max_days_per_run && foundPrices; i++) {
                 // get the price with the oldest timestamp
                 const oldestPrice = await this.query(`
                     SELECT * FROM price_data 
@@ -27,6 +28,7 @@ class ArchivePricesJob extends DataJob {
                     // we don't have any prices before the cutoff
                     // this means archiving is current, so nothing to do
                     this.logger.success(`No ${gameMode.name} prices found before ${cutoff}`);
+                    foundPrices = false;
                     continue;
                 }
                 // convert oldest price date to YYYY-MM-dd
@@ -42,20 +44,34 @@ class ArchivePricesJob extends DataJob {
                     WHERE timestamp >= ? AND timestamp < ? + INTERVAL 1 DAY AND game_mode = ?
                     GROUP BY item_id
                 `, [archiveDate, archiveDate, gameMode.value]);
+
+                // get offer counts for day
+                const itemOfferCounts = await this.query(`
+                    SELECT item_id, MIN(offer_count) as offer_count_min, ROUND(AVG(offer_count)) as offer_count_avg
+                    FROM price_historical
+                    WHERE timestamp >= ? AND timestamp < ? + interval 1 DAY AND game_mode = ?
+                    GROUP BY item_id
+                `, [archiveDate, archiveDate, gameMode.value]);
     
                 // add min and average prices to price archive insert
                 const insertValues = [];
                 for (const itemPrice of itemPrices) {
-                    insertValues.push(itemPrice.item_id, archiveDate, itemPrice.min_price, Math.round(itemPrice.avg_price), gameMode.value);
+                    let offerCountMin, offerCountAvg;
+                    const itemOfferCount = itemOfferCounts.find(oc => oc.item_id === itemPrice.item_id);
+                    if (itemOfferCount) {
+                        offerCountMin = itemOfferCount.offer_count_min;
+                        offerCountAvg = itemOfferCount.offer_count_avg;
+                    }
+                    insertValues.push(itemPrice.item_id, archiveDate, itemPrice.min_price, Math.round(itemPrice.avg_price), offerCountMin, offerCountAvg, gameMode.value);
                 }
     
                 // insert archived prices
                 const insertStart = new Date();
                 await this.query(`
                     INSERT INTO price_archive
-                        (item_id, price_date, price_min, price_avg, game_mode)
+                        (item_id, price_date, price_min, price_avg, offer_count_min, offer_count_avg game_mode)
                     VALUES
-                        ${Object.keys(itemPrices).map(() => '(?, ?, ?, ?, ?)').join(', ')}
+                        ${Object.keys(itemPrices).map(() => '(?, ?, ?, ?, ?, ?, ?)').join(', ')}
                     ON DUPLICATE KEY UPDATE
                         price_min=VALUES(price_min), price_avg=VALUES(price_avg)
                 `, insertValues);
@@ -78,6 +94,14 @@ class ArchivePricesJob extends DataJob {
                     }
                 }
                 this.logger.log(`Deleted ${deletedCount} individual ${gameMode.name} prices in ${new Date() - deleteStart}ms`);
+
+                const historicalDeleteStart = new Date();
+                const historicalDeleteResult = await this.query(`
+                    DELETE FROM price_historical 
+                    WHERE timestamp < ? + INTERVAL 1 DAY AND game_mode = ?
+                `, [archiveDate, gameMode.value]);
+                const historicalDeleteCount = historicalDeleteResult.affectedRows;
+                this.logger.log(`Deleted ${historicalDeleteCount} historical ${gameMode.name} prices in ${new Date() - historicalDeleteStart}ms`);
             }
         }
     }

--- a/src/tarkov-data-manager/jobs/update-archived-prices.mjs
+++ b/src/tarkov-data-manager/jobs/update-archived-prices.mjs
@@ -46,7 +46,7 @@ class UpdateArchivedPricesJob extends DataJob {
             this.logger.time('archived-prices-query');
             const archivedPriceData = await this.batchQuery(`
                 SELECT
-                    item_id, price_date, price_min, price_avg
+                    item_id, price_date, price_min, price_avg, offer_count_min, offer_count_avg
                 FROM
                     price_archive
                 WHERE
@@ -69,6 +69,8 @@ class UpdateArchivedPricesJob extends DataJob {
                 archivedPrices[row.item_id].push({
                     priceMin: row.price_min,
                     price: row.price_avg,
+                    offerCountMin: row.offer_count_min ?? undefined,
+                    offerCount: row.offer_count_avg ?? undefined,
                     timestamp: row.price_date.getTime(),
                 });
             }

--- a/src/tarkov-data-manager/jobs/update-historical-prices.mjs
+++ b/src/tarkov-data-manager/jobs/update-historical-prices.mjs
@@ -16,10 +16,6 @@ class UpdateHistoricalPricesJob extends DataJob {
     async run() {
         this.kvData = {};
         const priceWindow = new Date(new Date().setDate(new Date().getDate() - historicalPriceDays));
-        const deleteResult = await this.query('DELETE FROM price_historical WHERE timestamp < ?', [priceWindow]);
-        if (deleteResult.affectedRows) {
-            this.logger.log(`Deleted ${deleteResult.affectedRows} historical prices before ${priceWindow}`);
-        }
         for (const gameMode of this.gameModes) {
             this.kvData[gameMode.name] = {};
             let kvName = this.kvName;

--- a/src/tarkov-data-manager/modules/tarkov-spt.mjs
+++ b/src/tarkov-data-manager/modules/tarkov-spt.mjs
@@ -118,6 +118,7 @@ const apiRequest = async (request, searchParams) => {
     }
     const url = `${sptApiPath}${request}`;
     const response = await got(url, {
+        throwHttpErrors: false,
         //responseType: 'json',
         searchParams: {
             //access_token: process.env.SPT_TOKEN,

--- a/src/tarkov-data-manager/modules/tarkov-spt.mjs
+++ b/src/tarkov-data-manager/modules/tarkov-spt.mjs
@@ -76,6 +76,7 @@ const downloadJson = async (fileName, path, download = false, writeFile = true, 
             await setBranch();
         }
         const response = await got(path.replace('{branch}', branch), {
+            throwHttpErrors: false,
             //responseType: 'json',
         });
         if (response.ok) {

--- a/src/tarkov-data-manager/modules/tarkov-spt.mjs
+++ b/src/tarkov-data-manager/modules/tarkov-spt.mjs
@@ -33,7 +33,7 @@ const sptLangs = {
 }
 
 const branches = [
-    '3.10.3-DEV',
+    '3.10.4-DEV',
     'master',
 ];
 
@@ -61,6 +61,7 @@ const setBranch = async () => {
     for (const b of branches) {    
         if (response.some(remoteBranch => remoteBranch.name === b)) {
             branch = b;
+            console.log('branch', branch);
             return;
         } else {
             await discordWebhook.alert({title: 'SPT repo branch not found', message: b});
@@ -115,15 +116,14 @@ const apiRequest = async (request, searchParams) => {
     if (!branch) {
         await setBranch();
     }
-    searchParams = {
-        //access_token: process.env.SPT_TOKEN,
-        ...searchParams,
-        ref: branch,
-    };
     const url = `${sptApiPath}${request}`;
     const response = await got(url, {
         //responseType: 'json',
-        searchParams: searchParams,
+        searchParams: {
+            //access_token: process.env.SPT_TOKEN,
+            ...searchParams,
+            ref: branch,
+        },
     });
     if (response.ok) {
         return JSON.parse(response.body);


### PR DESCRIPTION
The job to archive detailed prices now also reads offer counts from historical prices and includes those in the archived price data. Removing old historical prices is also moved from the historical prices job to the archive prices job.