### PR TITLE
Better barter unlocks

### DIFF
--- a/src/tarkov-data-manager/modules/tarkov-spt.mjs
+++ b/src/tarkov-data-manager/modules/tarkov-spt.mjs
@@ -36,7 +36,7 @@ const sptLangs = {
 }
 
 const branches = [
-    '4.0.0-DEV',
+    '3.11.0-dev',
     'master',
 ];
 


### PR DESCRIPTION
Only use quest barter unlocks a single time instead of using the same unlock for multiple barter offers. Really only matters for the new Price of Independence quests.