### PR TITLE
fix(de): translate more quest objective strings

### DIFF
--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -2342,6 +2342,11 @@
     "675c1d6d59b0575973008fc7": {
         "name": "Seizing the Initiative",
         "locale": {
+            "de": {
+                "675c1d6d59b0575973008fc7 name": "Die Initiative ergreifen",
+                "675c1d6d59b0575973008fc9": "Benutze den Transit von Customs nach Shoreline",
+                "675c1dbdcca03cb7f61fc735": "Überlebe und entkomme aus Shoreline"
+            },
             "zh": {
                 "675c1d6d59b0575973008fc7 name": "先声夺人"
             }
@@ -2551,6 +2556,145 @@
             },
             "zh": {
                 "6834202a186efa3c5b07f9a5": "在竞技场赢得两场 TeamFight 或 BlastGang 或 CheckPoint 模式的战斗，至少取得前三名的排名"
+            }
+        }
+    },
+    "66058cbb06ef1d50a60c1f46": {
+        "name": "Surprise [PVP ZONE]",
+        "locale": {
+            "de": {
+                "6606d08b4e2e27ca2d80085e": "Übergib im Raid gefundene ballistische Platten der Klasse 4 oder höher"
+            }
+        }
+    },
+    "68341b407559f4e6d50bc0ce": {
+        "name": "Surprise [PVE ZONE]",
+        "locale": {
+            "de": {
+                "68341b407559f4e6d50bc0d1": "Übergib im Raid gefundene ballistische Platten der Klasse 4 oder höher"
+            }
+        }
+    },
+    "66058cbf2f19c31a5a1337ec": {
+        "name": "Create a Distraction - Part 2 [PVP ZONE]",
+        "locale": {
+            "de": {
+                "660d5effb318c171fb1ca234": "Eliminiere Kabans oder Kollontays Wachen auf Streets of Tarkov"
+            }
+        }
+    },
+    "68341d7d7559f4e6d50bc0db": {
+        "name": "Create a Distraction - Part 2 [PVE ZONE]",
+        "locale": {
+            "de": {
+                "68341d7d7559f4e6d50bc0de": "Eliminiere Kabans oder Kollontays Wachen auf Streets of Tarkov"
+            }
+        }
+    },
+    "66058cc1da30b620a34e6e86": {
+        "name": "To Great Heights! - Part 1 [PVP ZONE]",
+        "locale": {
+            "de": {
+                "662ba5a89d8041c264dd9673": "Gewinne ein Match im CheckPoint- oder LastHero-Modus in Arena"
+            }
+        }
+    },
+    "68341eb25619c8e2a9031501": {
+        "name": "To Great Heights! - Part 1 [PVE ZONE]",
+        "locale": {
+            "de": {
+                "68341eb25619c8e2a9031504": "Gewinne ein Match im CheckPoint- oder LastHero-Modus in Arena"
+            }
+        }
+    },
+    "66058cc208308761cf390993": {
+        "name": "To Great Heights! - Part 2 [PVP ZONE]",
+        "locale": {
+            "de": {
+                "662ba78e19c86d3199ae0a93": "Gewinne ein Match im TeamFight-, BlastGang- oder CheckPoint-Modus in Arena"
+            }
+        }
+    },
+    "68341f6fe2e7ef70a3060a0a": {
+        "name": "To Great Heights! - Part 2 [PVE ZONE]",
+        "locale": {
+            "de": {
+                "68341f6fe2e7ef70a3060a0d": "Gewinne ein Match im TeamFight-, BlastGang- oder CheckPoint-Modus in Arena"
+            }
+        }
+    },
+    "66058cc72cee99303f1ba069": {
+        "name": "To Great Heights! - Part 4 [PVP ZONE]",
+        "locale": {
+            "de": {
+                "662bb23200ae352a6d5a415d": "Gewinne drei von sechs Matches im TeamFight-, BlastGang- oder CheckPoint-Modus in Arena",
+                "665493a649bd17856482ba77": "Die Aufgabe schlägt fehl, wenn du 4 Matches verlierst"
+            }
+        }
+    },
+    "683421515619c8e2a9031511": {
+        "name": "To Great Heights! - Part 4 [PVE ZONE]",
+        "locale": {
+            "de": {
+                "683421515619c8e2a9031515": "Gewinne drei von sechs Matches im TeamFight-, BlastGang- oder CheckPoint-Modus in Arena",
+                "683421515619c8e2a9031518": "Die Aufgabe schlägt fehl, wenn du 4 Matches verlierst"
+            }
+        }
+    },
+    "66058cc9ae4719735349b9ea": {
+        "name": "To Great Heights! - Part 5 [PVP ZONE]",
+        "locale": {
+            "de": {
+                "662ba87106e44407b79e9ab2": "Gewinne zwei Matches in Folge im TeamFight-, BlastGang- oder CheckPoint-Modus in Arena"
+            }
+        }
+    },
+    "68342265a8d674b5740b31f0": {
+        "name": "To Great Heights! - Part 5 [PVE ZONE]",
+        "locale": {
+            "de": {
+                "68342265a8d674b5740b31f3": "Gewinne zwei Matches in Folge im TeamFight-, BlastGang- oder CheckPoint-Modus in Arena"
+            }
+        }
+    },
+    "66058ccde8e4f17985230807": {
+        "name": "Against the Conscience - Part 2 [PVP ZONE]",
+        "locale": {
+            "de": {
+                "663b9bb7fe7953705cb09114": "Eliminiere Gegner in einem beliebigen Spielmodus in Arena"
+            }
+        }
+    },
+    "68342446a8d674b5740b31fc": {
+        "name": "Against the Conscience - Part 2 [PVE ZONE]",
+        "locale": {
+            "de": {
+                "68342446a8d674b5740b31ff": "Eliminiere Gegner in einem beliebigen Spielmodus in Arena"
+            }
+        }
+    },
+    "6834254f2f0e2a7eb90b62ef": {
+        "name": "Decisions, Decisions [PVE ZONE]",
+        "locale": {
+            "de": {
+                "6834254f2f0e2a7eb90b62f1": "Finde kompromittierende Informationen über Ref"
+            }
+        }
+    },
+    "66058ccbc7f3584787181478": {
+        "name": "Against the Conscience - Part 1 [PVP ZONE]",
+        "locale": {
+            "de": {
+                "67e6b531ca71d03c35350b31": "Finde und beschaffe den Schlüssel bei der Schmugglerbasis auf Shoreline"
+            }
+        }
+    },
+    "6834233fecd5cf3a440d855b": {
+        "name": "Against the Conscience - Part 1 [PVE ZONE]",
+        "locale": {
+            "de": {
+                "6834233fecd5cf3a440d855f": "Finde das Zimmer des alten Champions in Customs",
+                "6834233fecd5cf3a440d8567": "Finde und beschaffe den Schlüssel bei der Schmugglerbasis auf Shoreline"
             }
         }
     },

--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -2698,6 +2698,39 @@
             }
         }
     },
+    "5a0327ba86f77456b9154236": {
+        "name": "Spa Tour - Part 3",
+        "locale": {
+            "de": {
+                "5a03289686f7745dbc6c5063": "Übergib im Raid gefundenes WD-40",
+                "5a0328cb86f77456b91543b8": "Übergib im Raid gefundene Clin Glasreiniger",
+                "5a03290586f774584d1594c4": "Übergib im Raid gefundene Wellschläuche",
+                "5a280b5486f7741f751bfeea": "Übergib im Raid gefundenes Ox Bleichmittel"
+            }
+        }
+    },
+    "66aa74571e5e199ecd094f18": {
+        "name": "Secrets of Polikhim",
+        "locale": {
+            "de": {
+                "66aa74571e5e199ecd094f1b": "Benutze den Transit von Customs nach Factory (in einem Raid)",
+                "66aa74571e5e199ecd094f1e": "Eliminiere Scavs auf Factory (in einem Raid)"
+            }
+        }
+    },
+    "66aba85403e0ee3101042877": {
+        "name": "Beneath The Streets",
+        "locale": {
+            "de": {
+                "66aba85403e0ee3101042878": "Finde den Durchgang nach The Lab auf Streets of Tarkov (in einem Raid)",
+                "66aba85403e0ee310104287a": "Benutze den Transit von Streets of Tarkov nach The Lab (in einem Raid)",
+                "66b090f5723e7bbe8b518ca8": "Erkunde den Serverraum in The Lab (in einem Raid)",
+                "66b0910951c5294b9d213918": "Erkunde die Gefahrenkuppel in The Lab (in einem Raid)",
+                "66b10eef0951e90ec383850b": "Erkunde den Kontrollraum in The Lab (in einem Raid)",
+                "66aba97b1000025218c82ea8": "Finde den Durchgang nach Streets of Tarkov in The Lab (in einem Raid)"
+            }
+        }
+    },
     "66ab9da7eb102b9bcd08591c": {
         "name": "Forester's Duty",
         "locale": {

--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -2196,6 +2196,15 @@
         ]
     },
     "665eeca92f7aedcc900b0437": {
+        "name": "Thirsty - Secrets",
+        "locale": {
+            "de": {
+                "665eeca92f7aedcc900b0437 name": "Thirsty - Geheimnisse",
+                "6661a28be2cdba6a469447c7": "Übergib die im Raid gefundenen Adrenalinspritzen",
+                "6661a2ae387c59056c822add": "Übergib die im Raid gefundenen OLOLO Multivitaminpräparate",
+                "6661a2bf4846fd2b6ba30f90": "Übergib die im Raid gefundenen Kochsalzlösungen"
+            }
+        },
         "finishRewardsAdded": {
             "items": [
                 {
@@ -2780,6 +2789,31 @@
                 "6661a170945719c63f28d9c6": "Verstaue den ersten 5-Liter-Propantank",
                 "6661a18a12e8457716d59f5d": "Finde den angegebenen Ablageort in Customs",
                 "6661a1a1b1953d6c96da8f0e": "Verstaue den zweiten 5-Liter-Propantank"
+            }
+        }
+    },
+    "665eeca45d86b6c8aa03c79d": {
+        "name": "Thirsty - Echo",
+        "locale": {
+            "de": {
+                "665eeca45d86b6c8aa03c79d name": "Thirsty - Widerhall",
+                "6660785fc37356435d193ae4": "Finde Informationen über Thirsty auf Shoreline",
+                "66607896f2ea02201517c203": "Beschaffe die Informationen in Thirstys Versteck",
+                "666078bee6ed30ab2294f593": "Übergib die gefundenen Informationen"
+            }
+        }
+    },
+    "67a0964e972c11a3f507731b": {
+        "name": "Needle in a Haystack",
+        "locale": {
+            "de": {
+                "67a0964e972c11a3f507731b name": "Nadel im Heuhaufen",
+                "67a0bc81fcbc1c559d09b58f": "Untersuche den Innenhofpark beim TerraGroup-HQ auf Ground Zero",
+                "67a0bc83182c4b0c71edd0ce": "Untersuche die Kartbahn auf Interchange",
+                "67a0bc84f19d5b1120a55762": "Untersuche den Kinderspielplatz auf Interchange",
+                "67a0bc87c60a93d7a3f28b23": "Untersuche den Kinderspielplatz bei Concordia auf Streets of Tarkov",
+                "67a0bc8848d9d2cbd274ffd9": "Untersuche die Baustelle an der Küste auf Shoreline",
+                "67a0bc8ab12fe4b1baa60e4c": "Untersuche den Kinderspielplatz beim Health Resort auf Shoreline"
             }
         }
     },

--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -2731,6 +2731,58 @@
             }
         }
     },
+    "675c1570526ff496850895d9": {
+        "name": "Passion for Ergonomics",
+        "locale": {
+            "de": {
+                "675c1570526ff496850895d9 name": "Leidenschaft für Ergonomie",
+                "675c15916580a378dc0f012f": "Finde und beschaffe den angepassten Werkzeugsatz im Garagenkomplex in Customs",
+                "675c1595a4c063af74ee5279": "Übergib den gefundenen Gegenstand"
+            }
+        }
+    },
+    "67a09636b8725511260bc421": {
+        "name": "Shady Contractor",
+        "locale": {
+            "de": {
+                "67a09636b8725511260bc421 name": "Zwielichtiger Auftragnehmer",
+                "67a0a91f4681b4e43d13892b": "Finde das Auto des leitenden Managers von Knossos LLC auf Ground Zero",
+                "67a0ab610345d81cb3cbb24c": "Finde und beschaffe das Tagebuch des Managers",
+                "67a0ab83359e2d00cf9d6b06": "Übergib das Tagebuch"
+            }
+        }
+    },
+    "665eeacf5d86b6c8aa03c79b": {
+        "name": "Thirsty - Hounds",
+        "locale": {
+            "de": {
+                "665eeacf5d86b6c8aa03c79b name": "Thirsty - Jagdhunde",
+                "665eed28bdbf7b1f92394ecb": "Eliminiere Scavs im Zeitraum von 22:00 bis 07:00 Uhr auf Shoreline"
+            }
+        }
+    },
+    "665eec1f5e47a79f8605565a": {
+        "name": "Thirsty - Breadwinner",
+        "locale": {
+            "de": {
+                "665eec1f5e47a79f8605565a name": "Thirsty - Ernährer",
+                "665ef4d93bd11acd294ac48c": "Finde 5-Liter-Propantanks im Raid",
+                "665ef4f08f3a505364a8ab09": "Übergib die Gegenstände"
+            }
+        }
+    },
+    "665eec4a4dfc83b0ed0a9dca": {
+        "name": "Thirsty - Delivery",
+        "locale": {
+            "de": {
+                "665eec4a4dfc83b0ed0a9dca name": "Thirsty - Lieferung",
+                "6661a14545909ae2e92ca2d5": "Finde den angegebenen Ablageort in Woods",
+                "6661a170945719c63f28d9c6": "Verstaue den ersten 5-Liter-Propantank",
+                "6661a18a12e8457716d59f5d": "Finde den angegebenen Ablageort in Customs",
+                "6661a1a1b1953d6c96da8f0e": "Verstaue den zweiten 5-Liter-Propantank"
+            }
+        }
+    },
     "66ab9da7eb102b9bcd08591c": {
         "name": "Forester's Duty",
         "locale": {


### PR DESCRIPTION
## Summary

Adds German locale overrides for more quest objective strings that are currently still English.

## Quests

- Surprise
- Create a Distraction - Part 2
- To Great Heights! - Parts 1, 2, 4, 5
- Against the Conscience - Parts 1, 2
- Decisions, Decisions
- Seizing the Initiative
- Spa Tour - Part 3
- Secrets of Polikhim
- Beneath The Streets
- Passion for Ergonomics
- Shady Contractor
- Thirsty - Hounds
- Thirsty - Breadwinner
- Thirsty - Delivery
- Thirsty - Echo
- Thirsty - Secrets
- Needle in a Haystack

## Notes

For quests with separate PvP and PvE IDs, this PR adds German overrides for both variants.

This also fixes the German failure condition for `To Great Heights! - Part 4 [PVE ZONE]` from 5 lost matches to 4, matching the EN source.