### PR TITLE
fix(de): update Gendarmerie SMG objective

### DIFF
--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -2160,6 +2160,11 @@
     "64e7b9a4aac4cd0a726562cb": {
         "propertiesChanged": {
             "experience": 7500
+        },
+        "locale": {
+            "de": {
+                "64e7bd0c6393886f74119f41": "Eliminiere beliebige Gegner beim Rodina-Kino auf Streets of Tarkov mit SMGs"
+            }
         }
     },
     "64e7b99017ab941a6f7bf9d7": {


### PR DESCRIPTION
Updates the German objective text for Gendarmerie - Tickets, Please to use the common SMG wording.

The English objective refers to SMGs, while the current German text says Maschinenpistolen. This keeps the weapon class wording aligned with the English task text and common German Tarkov slang.