### PR TITLE
fix(static-api): upload locale files when main data is unchanged

### DIFF
--- a/src/tarkov-data-manager/modules/data-job.mjs
+++ b/src/tarkov-data-manager/modules/data-job.mjs
@@ -338,6 +338,14 @@ class DataJob {
         if (response.ok) {
             const currentValue = await response.text();
             if (dataString === currentValue) {
+                if (options.locale) {
+                    await this.putStaticApiLocale(key, options.locale);
+                    if (!options.skipPurge) {
+                        await this.purgeCachePrefix(publicPath);
+                    }
+                    this.logger.log(`Value of ${key} has not changed; updated locale files`);
+                    return;
+                }
                 this.logger.log(`Value of ${key} has not changed; skipping upload`);
                 return;
             }


### PR DESCRIPTION
## Summary

`r2Put()` returns early when `dataString === currentValue`. That also skipped `putStaticApiLocale()`, so translation-only updates could leave the static locale files stale even though the generated locale data had changed.

This can happen for task updates from `changed_quests.json`: the main `regular/tasks` payload still contains the same translation keys, while `regular/tasks_de` needs to be refreshed.

With this change, when `options.locale` is supplied and the main data is unchanged, the locale files are still uploaded and the cache prefix is purged. This matches the existing behavior of the data-changed path.

## Context

This came up while checking recent German quest translation updates. The `changed_quests.json` entries were already present in `main`, but `regular/tasks_de` / `pve/tasks_de` still served the old English fallback strings.

Since the base task payload still contained the same translation keys, only the generated locale files needed to be refreshed. That led back to the early return in `r2Put()`.