### PR TITLE
fix(de): restore Keeper's Word locale overrides

### DIFF
--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -2042,6 +2042,14 @@
                     ]
                 }
             ]
+        },
+        "locale": {
+            "de": {
+                "67a09761e720611a6a01f288 name": "Wort des Hüters",
+                "67a0e4df8cddbe2df31dd1d9": "Verstaue ein Kultistenmesser am ersten besonderen Ort im Labyrinth",
+                "67a0e4e399e34c9ffcdc6e00": "Verstaue ein Kultistenmesser am zweiten besonderen Ort im Labyrinth",
+                "67a0e4e64cb065811d95c6d9": "Verstaue ein Kultistenmesser am dritten besonderen Ort im Labyrinth"
+            }
         }
     },
     "66aa58245ab22944110db6e9": {


### PR DESCRIPTION
## Summary

Restores the German locale overrides for Keeper's Word.

The changed_quests duplicate cleanup kept the existing Keeper's Word block, but the German `locale.de` entries from the duplicate block were not merged back in.

This adds the missing task name and the three Labyrinth stash objective translations to the existing quest block.