### PR TITLE
Fix pvp-season profile index updates

### DIFF
--- a/src/tarkov-data-manager/jobs/update-profile-index.mjs
+++ b/src/tarkov-data-manager/jobs/update-profile-index.mjs
@@ -28,7 +28,7 @@ class UpdateProfileIndexJob extends DataJob {
         let offset = 0;
         while (true) {
             const queryResult = await this.d1Query(
-                'SELECT id, name, updated, updated_pve, updated_arena FROM eft_accounts LIMIT ?, ?',
+                'SELECT id, name, updated, updated_pve, updated_pvp_season, updated_arena FROM eft_accounts LIMIT ?, ?',
                 [offset, batchSize],
                 {
                     maxRetries: 10,
@@ -40,7 +40,7 @@ class UpdateProfileIndexJob extends DataJob {
                 for (const gameMode of gameModes) {
                     let updatedField = 'updated';
                     if (gameMode.name !== 'regular') {
-                        updatedField += `_${gameMode.name}`;
+                        updatedField += `_${gameMode.name.replaceAll('-', '_')}`;
                     }
                     if (r[updatedField]) {
                         profiles[gameMode.name][r.id] = r.name;


### PR DESCRIPTION
## Summary

Fix the profile index job so that seasonal player profiles are included in the static `players.tarkov.dev/pvp-season/index.json` and `updated.json` files.

## Root cause

`pvp-season` is now part of `modules/game-modes.mjs`, so `update-profile-index.mjs` iterates over it. However, the D1 query did not select the seasonal account timestamp, and the generic field construction produced `updated_pvp-season` instead of the database column name `updated_pvp_season`. As a result, no seasonal rows were added to the generated indices.

## Changes

- Select `updated_pvp_season` from `eft_accounts`.
- Normalize hyphens in game-mode names when resolving account timestamp fields.

The existing regular, PvE, and Arena paths are unchanged.

## Validation

- `node --check src/tarkov-data-manager/jobs/update-profile-index.mjs`
- `git diff --check`
