### PR TITLE
Remove the duplicate Ground Zero objective from Escort

### DIFF
--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -1600,42 +1600,6 @@
             "experience": 155000,
             "minPlayerLevel": 46
         },
-        "objectivesAdded": [
-            {
-                "id": "65e09b343458a36a766837c7",
-                "description": "65e09b343458a36a766837c7",
-                "type": "shoot",
-                "count": 4,
-                "optional": false,
-                "locationNames": [
-                    "65b8d6f5cdde2479cb2a3125 Name"
-                ],
-                "map_ids": [
-                    "65b8d6f5cdde2479cb2a3125"
-                ],
-                "zoneNames": [],
-                "target": "AnyPmc",
-                "shotType": "kill",
-                "bodyParts": [],
-                "usingWeapon": [],
-                "usingWeaponMods": [],
-                "distance": {
-                    "compareMethod": ">=",
-                    "value": 0
-                },
-                "timeFromHour": 0,
-                "timeUntilHour": 0,
-                "wearing": [],
-                "notWearing": [],
-                "healthEffect": null,
-                "enemyHealthEffect": null,
-                "targetNames": [
-                    "AnyPmc"
-                ],
-                "playerHealthEffect": null,
-                "zones": []
-            }
-        ],
         "finishRewardsChanged": {
             "skillLevelReward": [
                 {


### PR DESCRIPTION
The wiki lists **eight** objectives for Escort, one per map, each asking for two PMC operatives. The API serves **nine**.

## The extra objective

`65e09b343458a36a766837c7` is added by hand in `data/changed_quests.json`. It duplicates `65e19abadf39d26751b3bb1e`, which the game data already provides:

| objective | count | maps |
| --- | --- | --- |
| `65e19aba…bb1e` (game data) | 2 | Ground Zero, Ground Zero 21+ |
| `65e09b34…37c7` (added here) | 4 | Ground Zero 21+ only |

The first already covers both variants, so the second adds a ninth line to a quest that has eight, and asks for four kills where every other objective asks for two.

The guard in `update-quests.mjs` cannot catch this — it skips an addition when an objective with the same id is already present, and this is a different id describing the same task:

```js
if (questData.objectives.some(obj => obj.id === newObj.id)) {
    continue;
}
```

## Why it looks like a leftover

Two details in the same entry suggest it predates the API serving the combined objective and was never revisited:

Its `locale` block supplies only the quest name (`"Eskorte"` for `de`), so the objective renders **untranslated in every language other than English**. That is how I ran into it — a German quest list with one English line in the middle.

And `propertiesChanged` still sets `experience: 155000`, where the wiki says **+65,000 EXP**. I left that alone: I have not checked what the underlying API value is, so I do not know whether the right change is correcting it or dropping the override. Happy to follow up if you want it in the same PR.

## Independent confirmation

`tarkov-data-overlay` reached the same conclusion and suppresses the objective from its wiki discrepancy report, with the same wiki link as proof:

https://github.com/tarkovtracker-org/tarkov-data-overlay/blob/main/src/suppressions/tasks.json5

That only silences their report, though — the objective still reaches consumers.

## The change

One file, 36 lines removed, nothing else touched. `objectivesAdded` was the only key removed from the Escort entry; `propertiesChanged`, `finishRewardsChanged` and `locale` are unchanged.

Proof: https://escapefromtarkov.fandom.com/wiki/Escort
