### PR TITLE
fix: remove non-existent wrench hand-over objective from Minibus quest

### DIFF
--- a/src/tarkov-data-manager/data/changed_quests.json
+++ b/src/tarkov-data-manager/data/changed_quests.json
@@ -1,4 +1,14 @@
 {
+    "5b478d0f86f7744d190d91b5": {
+        "name": "Minibus",
+        "objectivesRemoved": [
+            {
+                "id": "6a60b0d2b5ca989d33e5b7e0",
+                "type": "giveItem",
+                "notes": "Per wiki - Minibus only requires marking 3 yellow minibuses with MS2000 Markers. The wrench hand-over objective does not exist in-game. Verified 2026-09-13."
+            }
+        ]
+    },
     "5c51aac186f77432ea65c552": {
         "name": "Collector",
         "taskRequirementsAdded": [


### PR DESCRIPTION
## Summary

The **Minibus** quest (5b478d0f86f7744d190d91b5, given by Ragman) currently has an incorrect giveItem objective (6a60b0d2b5ca989d33e5b7e0) requiring 10 wrenches found in raid.

According to the [wiki](https://escapefromtarkov.fandom.com/wiki/Minibus), Minibus only has **3 mark objectives** (locate and mark 3 yellow minibuses with MS2000 Markers on Interchange). There is no item hand-over requirement.

This causes trackers such as tarkovtracker.org to incorrectly show Minibus as needing pipe grip wrenches, ratchet wrenches, etc. under 'Needed Items'.

<img width="212" height="362" alt="image" src="https://github.com/user-attachments/assets/0b0bf27a-f1dc-46cf-a07f-df5d704fc945" />


### Fix
- Added Minibus to \changed_quests.json\ with \objectivesRemoved\ entry for the fake wrench objective.

## Related issue
**Pay the Fare!** (Ragman) is also completely missing from the dataset. It requires:
- Pipe grip wrench x1 (FiR)
- Ratchet wrench x1 (FiR)
- Electric drill x1 (FiR)

Wiki: [https://escapefromtarkov.fandom.com/wiki/Pay_the_Fare!](https://escapefromtarkov.fandom.com/wiki/Pay_the_Fare!)

The internal quest ID is unknown without game file extraction — flagging here for maintainer follow-up.

## Verification
- Wiki cross-checked on 2026-09-13
- Confirmed via \json.tarkov.dev/regular/tasks\ that the wrench objective exists in extracted data but not in-game